### PR TITLE
Fix ctype conversions

### DIFF
--- a/PyMemoryEditor/linux/functions.py
+++ b/PyMemoryEditor/linux/functions.py
@@ -69,7 +69,7 @@ def read_process_memory(
     )
 
     if pytype is str:
-        return data.value.decode()
+        return bytes(data).decode()
     elif pytype is bytes:
         return bytes(data)
     else:

--- a/PyMemoryEditor/linux/functions.py
+++ b/PyMemoryEditor/linux/functions.py
@@ -67,7 +67,13 @@ def read_process_memory(
         pid, (iovec * 1)(iovec(addressof(data), sizeof(data))),
         1, (iovec * 1)(iovec(address, sizeof(data))), 1, 0
     )
-    return data.value.decode() if pytype is str else data.value
+
+    if pytype is str:
+        return data.value.decode()
+    elif pytype is bytes:
+        return bytes(data)
+    else:
+        return data.value
 
 
 def search_addresses_by_value(

--- a/PyMemoryEditor/util/convert.py
+++ b/PyMemoryEditor/util/convert.py
@@ -32,9 +32,10 @@ def get_c_type_of(pytype: Type, length) -> ctypes._SimpleCData:
         if length <= 4: return ctypes.c_int32()     # 4 Bytes
         return ctypes.c_int64()                     # 8 Bytes
 
-    # Float values lose their precision when converted to c_float. For that reason,
-    # any float value will be converted to double.
-    elif pytype is float: return ctypes.c_double()  # 8 Bytes
+    elif pytype is float:
+
+        if length == 4: return ctypes.c_float()     # 4 Bytes
+        return ctypes.c_double()                    # 8 Bytes
 
     elif pytype is bool: return ctypes.c_bool()
 

--- a/PyMemoryEditor/win32/functions.py
+++ b/PyMemoryEditor/win32/functions.py
@@ -128,7 +128,7 @@ def ReadProcessMemory(
     kernel32.ReadProcessMemory(process_handle, ctypes.c_void_p(address), ctypes.byref(data), bufflength, None)
 
     if pytype is str:
-        return data.value.decode()
+        return bytes(data).decode()
     elif pytype is bytes:
         return bytes(data)
     else:

--- a/PyMemoryEditor/win32/functions.py
+++ b/PyMemoryEditor/win32/functions.py
@@ -127,7 +127,12 @@ def ReadProcessMemory(
     data = get_c_type_of(pytype, bufflength)
     kernel32.ReadProcessMemory(process_handle, ctypes.c_void_p(address), ctypes.byref(data), bufflength, None)
 
-    return data.value.decode() if pytype is str else data.value
+    if pytype is str:
+        return data.value.decode()
+    elif pytype is bytes:
+        return bytes(data)
+    else:
+        return data.value
 
 
 def SearchAddressesByValue(


### PR DESCRIPTION
Fixes allowing you to read 32 bit floats from the target process. Only 64 bit floats were being converted before.
This should fix #6 and #8 

Fixes bytes being properly converted from the ctype buffer. Before, attempting to get bytes from `data.value` would truncate the data like a null terminated string. According to the python docs, you should call `bytes(data)` to retrieve the entire buffer as bytes, examples here: https://docs.python.org/3/library/ctypes.html#ctypes.create_string_buffer
I think this fixes #7, #9, and #11