### PR TITLE
Fixing search_by_value on Windows

### DIFF
--- a/PyMemoryEditor/win32/enums/memory_protections.py
+++ b/PyMemoryEditor/win32/enums/memory_protections.py
@@ -57,7 +57,7 @@ class MemoryProtectionsEnum(Enum):
     PAGE_READWRITE = 0x04
 
     # Indicates memory page is readable. (Custom constant)
-    PAGE_READABLE = PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_READWRITE
+    PAGE_READABLE = PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_READWRITE | PAGE_READONLY
 
     # Indicates memory page is readable and writeable. (Custom constant)
     PAGE_READWRITEABLE = PAGE_EXECUTE_READWRITE | PAGE_READWRITE

--- a/PyMemoryEditor/win32/functions.py
+++ b/PyMemoryEditor/win32/functions.py
@@ -174,7 +174,8 @@ def SearchAddressesByValue(
 
         # Only committed, non-shared and readable memory pages.
         if region["struct"].State != MemoryAllocationStatesEnum.MEM_COMMIT.value: continue
-        if region["struct"].Type != MemoryTypesEnum.MEM_PRIVATE.value: continue
+        if (region["struct"].Type != MemoryTypesEnum.MEM_PRIVATE.value and
+                region["struct"].Type != MemoryTypesEnum.MEM_IMAGE.value): continue
         if region["struct"].Protect & MemoryProtectionsEnum.PAGE_READABLE.value == 0: continue
 
         # If writeable_only is True, checks if the memory page is writeable.


### PR DESCRIPTION
This PR change Readonly Region as Readable and add the Region of type image (the program Region that contain constants) as searchable too. It fixes the issue https://github.com/JeanExtreme002/PyMemoryEditor/issues/13.