### PR TITLE
feat: enumerate loaded modules via get_modules()

### DIFF
--- a/PyMemoryEditor/__init__.py
+++ b/PyMemoryEditor/__init__.py
@@ -23,6 +23,7 @@ from .process.errors import (
     ProcessNotFoundError,
     PyMemoryEditorError,
 )
+from .process.module_info import ModuleInfo
 from .process.thread_info import ThreadInfo
 
 
@@ -81,6 +82,7 @@ __all__ = (
     "AbstractProcess",
     "AmbiguousProcessNameError",
     "ClosedProcess",
+    "ModuleInfo",
     "OpenProcess",
     "ProcessIDNotExistsError",
     "ProcessNotFoundError",

--- a/PyMemoryEditor/app/main_window.py
+++ b/PyMemoryEditor/app/main_window.py
@@ -52,6 +52,7 @@ from .cheat_table import CheatTable
 from .log_console_dialog import LogConsoleDialog
 from .memory_map_dialog import MemoryMapDialog
 from .memory_viewer_dialog import MemoryViewerDialog
+from .modules_dialog import ModulesDialog
 from .pointer_chain_dialog import PointerChainDialog
 from .results_view import ResultsModel, ResultsView
 from .scan_worker import FirstScanWorker, RefineScanWorker, ScanRequest
@@ -92,6 +93,7 @@ class MainWindow(QMainWindow):
         # cached so subsequent opens reuse the same window (matches the
         # behavior of the existing memory_map dialog).
         self._threads_dialog: Optional[ThreadsDialog] = None
+        self._modules_dialog: Optional[ModulesDialog] = None
         self._pointer_chain_dialog: Optional[PointerChainDialog] = None
         self._log_console_dialog: Optional[LogConsoleDialog] = None
 
@@ -241,6 +243,11 @@ class MainWindow(QMainWindow):
         threads_action.triggered.connect(self._open_threads_dialog)
         tools_menu.addAction(threads_action)
 
+        modules_action = QAction("Modules…", self)
+        modules_action.setShortcut(QKeySequence("Ctrl+Shift+M"))
+        modules_action.triggered.connect(self._open_modules_dialog)
+        tools_menu.addAction(modules_action)
+
         pointer_chain_action = QAction("Resolve Pointer Chain…", self)
         pointer_chain_action.setShortcut(QKeySequence("Ctrl+Shift+P"))
         pointer_chain_action.triggered.connect(self._open_pointer_chain_dialog)
@@ -265,6 +272,7 @@ class MainWindow(QMainWindow):
         toolbar = QToolBar("Main", self)
         toolbar.setMovable(False)
         toolbar.addAction(memory_map_action)
+        toolbar.addAction(modules_action)
         toolbar.addAction(hex_viewer_action)
         toolbar.addAction(pointer_chain_action)
         toolbar.addSeparator()
@@ -531,6 +539,22 @@ class MainWindow(QMainWindow):
     def _on_threads_dialog_closed(self, _result: int) -> None:
         self._threads_dialog = None
 
+    def _open_modules_dialog(self) -> None:
+        if self._modules_dialog is None:
+            self._modules_dialog = ModulesDialog(self._process, self)
+            self._modules_dialog.open_hex_viewer.connect(
+                self._open_hex_viewer_with_size
+            )
+            self._modules_dialog.finished.connect(self._on_modules_dialog_closed)
+        else:
+            self._modules_dialog.refresh()
+        self._modules_dialog.show()
+        self._modules_dialog.raise_()
+        self._modules_dialog.activateWindow()
+
+    def _on_modules_dialog_closed(self, _result: int) -> None:
+        self._modules_dialog = None
+
     def _open_pointer_chain_dialog(self) -> None:
         if self._pointer_chain_dialog is None:
             self._pointer_chain_dialog = PointerChainDialog(self._process, self)
@@ -707,6 +731,7 @@ class MainWindow(QMainWindow):
         # process — reopening them rebuilds against the new target.
         for dialog_attr in (
             "_threads_dialog",
+            "_modules_dialog",
             "_pointer_chain_dialog",
         ):
             existing = getattr(self, dialog_attr, None)

--- a/PyMemoryEditor/app/modules_dialog.py
+++ b/PyMemoryEditor/app/modules_dialog.py
@@ -1,0 +1,267 @@
+# -*- coding: utf-8 -*-
+"""
+Modules dialog — exposes ``process.get_modules()``.
+
+Lists every module (the main executable plus each loaded shared library) the
+target process has mapped, with its name, base address, size and backing path.
+The toolbar lets the user:
+
+* refresh the list,
+* filter by name / path (a real process loads hundreds of modules),
+* copy a module's base address,
+* jump straight into the hex viewer at the module base.
+
+The base address is the most useful field here: combined with a static offset
+(``base + offset``) it survives ASLR, which is exactly what the Pointer Chain
+tool consumes. Lives alongside the Memory Map and Threads dialogs — same shape,
+same patterns (background worker, sortable table, Close button).
+"""
+from typing import List, Optional
+
+from PySide6.QtCore import Qt, QThread, Signal
+from PySide6.QtGui import QGuiApplication, QStandardItem, QStandardItemModel
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QDialog,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QTableView,
+    QVBoxLayout,
+)
+
+from PyMemoryEditor import AbstractProcess, ModuleInfo
+
+from ._widgets import NumericItem
+from .memory_map_dialog import _format_size
+
+
+class _ModulesWorker(QThread):
+    """Background thread that runs ``process.get_modules()`` off the UI."""
+
+    modules_ready = Signal(object)  # List[ModuleInfo]
+    modules_failed = Signal(str)
+
+    def __init__(self, process: AbstractProcess, parent=None):
+        super().__init__(parent)
+        self._process = process
+
+    def run(self) -> None:
+        try:
+            modules = list(self._process.get_modules())
+        except Exception as exc:  # noqa: BLE001
+            self.modules_failed.emit(str(exc))
+            return
+        self.modules_ready.emit(modules)
+
+
+class ModulesDialog(QDialog):
+    """Shows the output of ``get_modules()`` in a sortable, filterable table."""
+
+    # qulonglong: 64-bit addresses overflow Qt's default (C++ signed 32-bit) int.
+    open_hex_viewer = Signal("qulonglong", "qulonglong")  # (address, length)
+
+    def __init__(self, process: AbstractProcess, parent=None):
+        super().__init__(parent)
+        self._process = process
+        self._modules: List[ModuleInfo] = []
+        self._worker: Optional[_ModulesWorker] = None
+
+        self.setWindowTitle(f"Modules — PID {process.pid}")
+        self.resize(820, 560)
+
+        self._build_ui()
+        self.refresh()
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(14, 14, 14, 14)
+        layout.setSpacing(10)
+
+        header = QLabel(
+            f"<span style='font-size:16px;font-weight:700;'>Modules</span>"
+            f" &nbsp;<span style='color:#6E7681;'>PID {self._process.pid}</span>"
+        )
+        header.setTextFormat(Qt.RichText)
+        layout.addWidget(header)
+
+        self._count_label = QLabel("")
+        self._count_label.setObjectName("hint")
+        layout.addWidget(self._count_label)
+
+        bar = QHBoxLayout()
+        bar.setSpacing(8)
+
+        self._refresh_btn = QPushButton("Refresh")
+        self._refresh_btn.clicked.connect(self.refresh)
+        bar.addWidget(self._refresh_btn)
+
+        self._copy_btn = QPushButton("Copy Base Address")
+        self._copy_btn.clicked.connect(self._copy_selected_address)
+        bar.addWidget(self._copy_btn)
+
+        self._hex_btn = QPushButton("Open in Hex Viewer")
+        self._hex_btn.clicked.connect(self._emit_hex_viewer_request)
+        bar.addWidget(self._hex_btn)
+
+        bar.addStretch(1)
+
+        self._filter_edit = QLineEdit()
+        self._filter_edit.setPlaceholderText("Filter by name or path…")
+        self._filter_edit.setClearButtonEnabled(True)
+        self._filter_edit.setFixedWidth(220)
+        self._filter_edit.textChanged.connect(self._apply_filter)
+        bar.addWidget(self._filter_edit)
+
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(self.accept)
+        bar.addWidget(close_btn)
+        layout.addLayout(bar)
+
+        # Column 4 (raw size) is hidden — it only exists so the Size column
+        # sorts by the underlying byte count rather than the formatted label.
+        self._model = QStandardItemModel(0, 5, self)
+        self._model.setHorizontalHeaderLabels(
+            ["Name", "Base Address", "Size", "Path", "Size (Bytes)"]
+        )
+
+        self._table = QTableView()
+        self._table.setModel(self._model)
+        self._table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self._table.setSelectionMode(QAbstractItemView.SingleSelection)
+        self._table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self._table.setSortingEnabled(True)
+        self._table.setAlternatingRowColors(True)
+        self._table.verticalHeader().setVisible(False)
+        self._table.horizontalHeader().setStretchLastSection(False)
+        self._table.horizontalHeader().setSectionResizeMode(
+            0, QHeaderView.ResizeToContents
+        )
+        self._table.horizontalHeader().setSectionResizeMode(
+            1, QHeaderView.ResizeToContents
+        )
+        self._table.horizontalHeader().setSectionResizeMode(3, QHeaderView.Stretch)
+        self._table.setColumnHidden(4, True)
+        self._table.doubleClicked.connect(lambda _i: self._emit_hex_viewer_request())
+        layout.addWidget(self._table, 1)
+
+    def refresh(self) -> None:
+        # Don't stack workers — if a refresh is in flight, ignore the click.
+        if self._worker is not None and self._worker.isRunning():
+            return
+
+        self._count_label.setText("Enumerating modules…")
+        self._set_busy(True)
+
+        worker = _ModulesWorker(self._process, self)
+        worker.modules_ready.connect(self._on_modules_ready)
+        worker.modules_failed.connect(self._on_modules_failed)
+        worker.finished.connect(self._on_worker_finished)
+        self._worker = worker
+        worker.start()
+
+    def _set_busy(self, busy: bool) -> None:
+        self._refresh_btn.setEnabled(not busy)
+        self._copy_btn.setEnabled(not busy)
+        self._hex_btn.setEnabled(not busy)
+
+    def _on_modules_ready(self, modules) -> None:
+        self._modules = list(modules)
+        self._apply_filter()
+
+    def _apply_filter(self) -> None:
+        """Repopulate the table from the cached module list, honoring the filter."""
+        needle = self._filter_edit.text().strip().lower()
+
+        # Sorting is re-applied by the view; disable it while we rebuild so the
+        # model isn't re-sorted on every appendRow (also avoids row shuffling).
+        self._table.setSortingEnabled(False)
+        self._model.setRowCount(0)
+
+        shown = 0
+        for module in self._modules:
+            if needle and needle not in module.name.lower() and needle not in module.path.lower():
+                continue
+            shown += 1
+
+            name_item = QStandardItem(module.name or "—")
+
+            base = int(module.base_address)
+            base_item = NumericItem(f"0x{base:016X}")
+            base_item.setData(base, Qt.UserRole)
+
+            size = int(module.size)
+            size_item = NumericItem(_format_size(size))
+            size_item.setData(size, Qt.UserRole)
+            size_item.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)
+
+            path_item = QStandardItem(module.path or "")
+
+            raw_size_item = NumericItem(str(size))
+            raw_size_item.setData(size, Qt.UserRole)
+
+            self._model.appendRow(
+                [name_item, base_item, size_item, path_item, raw_size_item]
+            )
+
+        self._table.setSortingEnabled(True)
+
+        total = len(self._modules)
+        if needle:
+            self._count_label.setText(f"{shown:,} of {total:,} module(s) shown")
+        else:
+            self._count_label.setText(f"{total:,} module(s)")
+
+    def _on_modules_failed(self, message: str) -> None:
+        self._count_label.setText("Failed to enumerate modules.")
+        QMessageBox.critical(
+            self, "Modules", f"Failed to enumerate modules:\n\n{message}"
+        )
+
+    def _on_worker_finished(self) -> None:
+        self._set_busy(False)
+        worker = self._worker
+        self._worker = None
+        if worker is not None:
+            worker.deleteLater()
+
+    def _selected_module(self) -> Optional[dict]:
+        rows = self._table.selectionModel().selectedRows()
+        if not rows:
+            return None
+        row = rows[0].row()
+        base = self._model.item(row, 1).data(Qt.UserRole)
+        size = self._model.item(row, 2).data(Qt.UserRole)
+        return {"base_address": int(base), "size": int(size)}
+
+    def _copy_selected_address(self) -> None:
+        module = self._selected_module()
+        if module is None:
+            QMessageBox.information(self, "Modules", "Select a module first.")
+            return
+        QGuiApplication.clipboard().setText(f"{module['base_address']:X}")
+
+    def _emit_hex_viewer_request(self) -> None:
+        module = self._selected_module()
+        if module is None:
+            QMessageBox.information(self, "Modules", "Select a module first.")
+            return
+        # Cap the initial view to keep the hex widget responsive on big modules.
+        size = min(module["size"] or 4096, 4096)
+        self.open_hex_viewer.emit(module["base_address"], size)
+
+    def closeEvent(self, event):  # noqa: N802 — Qt naming
+        # If the enumeration is still in flight, let it finish but unhook our
+        # slots so a late emit doesn't touch a destroyed dialog.
+        if self._worker is not None and self._worker.isRunning():
+            try:
+                self._worker.modules_ready.disconnect()
+                self._worker.modules_failed.disconnect()
+                self._worker.finished.disconnect()
+            except (RuntimeError, TypeError):
+                pass
+            self._worker.wait(1000)
+        super().closeEvent(event)

--- a/PyMemoryEditor/linux/functions.py
+++ b/PyMemoryEditor/linux/functions.py
@@ -14,6 +14,7 @@ from ctypes import addressof, sizeof
 from typing import Dict, Generator, Optional, Sequence, Tuple, Type, TypeVar, Union
 
 from ..enums import ScanTypesEnum
+from ..process.module_info import ModuleInfo
 from ..process.region import enrich_region
 from ..process.scanning import (
     iter_pattern_results,
@@ -168,6 +169,55 @@ def get_memory_regions(pid: int) -> Generator[dict, None, None]:
                     "struct": region,
                 }
             )
+
+
+def get_modules(pid: int) -> Generator[ModuleInfo, None, None]:
+    """
+    Yield a :class:`ModuleInfo` for every file-backed module mapped by the
+    process, derived from ``/proc/<pid>/maps``.
+
+    A single library spans several consecutive mappings (its ``.text``,
+    ``.rodata``, ``.data`` / ``.bss`` segments), all sharing the same backing
+    path. Mappings are grouped by path: the module's ``base_address`` is the
+    lowest mapping start and its ``size`` reaches the highest mapping end.
+
+    Pseudo-mappings without a real backing file (``[heap]``, ``[stack]``,
+    ``[vvar]``, anonymous memory) are not modules and are skipped — only paths
+    beginning with ``/`` are considered. Modules are yielded in ascending
+    ``base_address`` order, which is the order ``/proc/<pid>/maps`` lists them.
+    """
+    # path -> [min_start, max_end]; first_seen preserves the maps order, which
+    # is already ascending by address, so we don't need to sort afterwards.
+    bounds: Dict[str, list] = {}
+    first_seen = []
+
+    for region in get_memory_regions(pid):
+        path = region["path"]
+        if not path.startswith("/"):
+            continue
+
+        start = region["address"]
+        end = start + region["size"]
+
+        entry = bounds.get(path)
+        if entry is None:
+            bounds[path] = [start, end]
+            first_seen.append(path)
+        else:
+            if start < entry[0]:
+                entry[0] = start
+            if end > entry[1]:
+                entry[1] = end
+
+    for path in first_seen:
+        start, end = bounds[path]
+        yield ModuleInfo(
+            name=os.path.basename(path),
+            path=path,
+            base_address=start,
+            size=end - start,
+            raw=path,
+        )
 
 
 def read_process_memory(pid: int, address: int, pytype: Type[T], bufflength: int) -> T:

--- a/PyMemoryEditor/linux/process.py
+++ b/PyMemoryEditor/linux/process.py
@@ -7,9 +7,11 @@ from ..enums import ScanTypesEnum
 from ..process import AbstractProcess
 from ..process.errors import ClosedProcess
 from ..util import resolve_bufflength
+from ..process.module_info import ModuleInfo
 from ..process.thread_info import ThreadInfo
 from .functions import (
     get_memory_regions,
+    get_modules,
     get_threads,
     read_process_memory,
     search_addresses_by_pattern,
@@ -83,6 +85,10 @@ class LinuxProcess(AbstractProcess):
     def get_threads(self) -> Generator[ThreadInfo, None, None]:
         self.__require_open()
         return get_threads(self.pid)
+
+    def get_modules(self) -> Generator[ModuleInfo, None, None]:
+        self.__require_open()
+        return get_modules(self.pid)
 
     def read_process_memory(
         self,

--- a/PyMemoryEditor/macos/functions.py
+++ b/PyMemoryEditor/macos/functions.py
@@ -12,6 +12,7 @@ import warnings
 from typing import Dict, Generator, Optional, Sequence, Tuple, Type, TypeVar, Union
 
 from ..enums import ScanTypesEnum
+from ..process.module_info import ModuleInfo
 from ..process.region import enrich_region
 from ..process.scanning import (
     iter_pattern_results,
@@ -34,6 +35,8 @@ from .types import (
     KERN_PROTECTION_FAILURE,
     KERN_SUCCESS,
     MEMORY_BASIC_INFORMATION,
+    TASK_DYLD_INFO,
+    TASK_DYLD_INFO_COUNT,
     VM_PROT_COPY,
     VM_PROT_READ,
     VM_PROT_WRITE,
@@ -43,6 +46,7 @@ from .types import (
     mach_port_t,
     mach_vm_address_t,
     mach_vm_size_t,
+    task_dyld_info_data_t,
     vm_region_basic_info_64,
 )
 
@@ -453,6 +457,169 @@ def get_threads(task: int) -> Generator[ThreadInfo, None, None]:
                 ctypes.cast(thread_list, ctypes.c_void_p),
                 count.value * ctypes.sizeof(ctypes.c_uint),
             )
+
+
+# Mach-O constants for sizing an image from its load commands.
+_MH_MAGIC_64 = 0xFEEDFACF
+_LC_SEGMENT_64 = 0x19
+_MACH_HEADER_64_SIZE = 32  # sizeof(struct mach_header_64)
+
+
+def _read_cstring(task: int, address: int, *, max_length: int = 4096) -> str:
+    """
+    Read a NUL-terminated UTF-8 string from the target task starting at
+    ``address``. Reads in small chunks and shrinks the chunk near an unmapped
+    boundary so a path that ends close to the edge of a mapping still comes
+    back intact. Returns the decoded text (``errors="replace"``).
+    """
+    data = bytearray()
+    chunk = 256
+
+    while len(data) < max_length:
+        try:
+            piece = read_process_memory(task, address + len(data), bytes, chunk)
+        except MachReadError:
+            # The read crossed into an unmapped page; retry with a smaller
+            # window. Give up only once even a single byte can't be read.
+            if chunk == 1:
+                break
+            chunk = max(1, chunk // 4)
+            continue
+
+        nul = piece.find(b"\x00")
+        if nul != -1:
+            data.extend(piece[:nul])
+            break
+        data.extend(piece)
+
+    return bytes(data[:max_length]).decode("utf-8", errors="replace")
+
+
+def _macho_image_size(task: int, load_address: int) -> int:
+    """
+    Return the size of the ``__TEXT`` segment of the Mach-O image at
+    ``load_address`` (its read-only code/constants), parsed from the load
+    commands. Returns 0 when the header is unreadable or not a 64-bit Mach-O.
+
+    macOS makes a single whole-module size hard to define: dylibs in the dyld
+    *shared cache* have their segments scattered across the cache (so a span
+    measurement is multi-gigabyte garbage), and several segments — ``__LINKEDIT``
+    and the ``__OBJC_RO`` / ``__OBJC_RW`` runtime tables — are *merged blobs
+    shared by every dylib*, so summing them double-counts hundreds of MB onto
+    each module. ``__TEXT`` is the one segment that is always private to the
+    image and accurately sized on and off the cache, and it is the region a
+    code/AOB scan cares about — so it is the most useful, stable choice here.
+    """
+    try:
+        header = read_process_memory(task, load_address, bytes, _MACH_HEADER_64_SIZE)
+    except MachReadError:
+        return 0
+
+    if int.from_bytes(header[:4], "little") != _MH_MAGIC_64:
+        return 0
+
+    ncmds = int.from_bytes(header[16:20], "little")
+    cmd_address = load_address + _MACH_HEADER_64_SIZE
+
+    for _ in range(ncmds):
+        try:
+            cmd_header = read_process_memory(task, cmd_address, bytes, 8)
+        except MachReadError:
+            break
+
+        cmd = int.from_bytes(cmd_header[:4], "little")
+        cmd_size = int.from_bytes(cmd_header[4:8], "little")
+        if cmd_size == 0:
+            break  # malformed — avoid an infinite loop
+
+        if cmd == _LC_SEGMENT_64:
+            # struct segment_command_64: cmd, cmdsize, segname[16],
+            # vmaddr (u64 @ offset 24), vmsize (u64 @ offset 32), ...
+            try:
+                seg = read_process_memory(task, cmd_address, bytes, 40)
+            except MachReadError:
+                break
+
+            if seg[8:24].split(b"\x00", 1)[0] == b"__TEXT":
+                return int.from_bytes(seg[32:40], "little")
+
+        cmd_address += cmd_size
+
+    return 0
+
+
+def get_modules(task: int) -> Generator[ModuleInfo, None, None]:
+    """
+    Yield a :class:`ModuleInfo` for every Mach-O image loaded in the task — the
+    main executable plus every linked dylib.
+
+    Walks dyld's image table: ``task_info(TASK_DYLD_INFO)`` returns the address
+    of ``dyld_all_image_infos`` inside the target, then the image array is read
+    out of the target's memory. Pointer-sized fields are read as 8 bytes (the
+    macOS backend targets 64-bit tasks). ``size`` is derived from each image's
+    Mach-O load commands (see :func:`_macho_image_size`); it falls back to 0 if
+    the header can't be parsed.
+    """
+    info = task_dyld_info_data_t()
+    count = mach_msg_type_number_t(TASK_DYLD_INFO_COUNT)
+
+    kr = libsystem.task_info(
+        task, TASK_DYLD_INFO, ctypes.byref(info), ctypes.byref(count)
+    )
+    if kr != KERN_SUCCESS:
+        raise OSError(
+            "task_info(TASK_DYLD_INFO) failed: %s (kr=%d)"
+            % (mach_error_message(kr), kr)
+        )
+
+    all_infos_address = info.all_image_info_addr
+    if not all_infos_address:
+        return
+
+    pointer_size = 8  # 64-bit task
+
+    def read_pointer(address: int) -> int:
+        return int.from_bytes(
+            read_process_memory(task, address, bytes, pointer_size), "little"
+        )
+
+    def read_u32(address: int) -> int:
+        return int.from_bytes(read_process_memory(task, address, bytes, 4), "little")
+
+    # struct dyld_all_image_infos { uint32 version; uint32 infoArrayCount;
+    #     const struct dyld_image_info* infoArray; ... }
+    try:
+        image_count = read_u32(all_infos_address + 4)
+        info_array_address = read_pointer(all_infos_address + 8)
+    except MachReadError as exc:
+        raise OSError("could not read dyld_all_image_infos: %s" % exc)
+
+    if not info_array_address or image_count == 0:
+        return
+
+    # struct dyld_image_info { const mach_header* imageLoadAddress;
+    #     const char* imageFilePath; uintptr_t imageFileModDate; } — 3 pointers.
+    entry_size = pointer_size * 3
+
+    for index in range(image_count):
+        entry_address = info_array_address + index * entry_size
+        try:
+            load_address = read_pointer(entry_address)
+            path_address = read_pointer(entry_address + pointer_size)
+        except MachReadError as exc:
+            _logger.debug("get_modules: skipping image %d: %s", index, exc)
+            continue
+
+        path = _read_cstring(task, path_address) if path_address else ""
+        name = os.path.basename(path) if path else ""
+
+        yield ModuleInfo(
+            name=name,
+            path=path,
+            base_address=load_address,
+            size=_macho_image_size(task, load_address),
+            raw=load_address,
+        )
 
 
 def search_addresses_by_pattern(

--- a/PyMemoryEditor/macos/libsystem.py
+++ b/PyMemoryEditor/macos/libsystem.py
@@ -107,6 +107,20 @@ libsystem.mach_vm_protect.restype = kern_return_t
 libsystem.mach_port_deallocate.argtypes = (mach_port_t, mach_port_t)
 libsystem.mach_port_deallocate.restype = kern_return_t
 
+# kern_return_t task_info(
+#     task_name_t              target_task,
+#     task_flavor_t            flavor,
+#     task_info_t              task_info_out,    /* out buffer */
+#     mach_msg_type_number_t  *task_info_outCnt);
+# Used with TASK_DYLD_INFO to locate dyld's image list for get_modules().
+libsystem.task_info.argtypes = (
+    task_t,
+    ctypes.c_uint,  # task_flavor_t
+    ctypes.c_void_p,  # task_info_t (caller-sized out buffer)
+    POINTER(mach_msg_type_number_t),
+)
+libsystem.task_info.restype = kern_return_t
+
 # kern_return_t task_threads(
 #     task_inspect_t           target_task,
 #     thread_act_array_t      *act_list,         /* out: kernel-allocated array of thread ports */

--- a/PyMemoryEditor/macos/process.py
+++ b/PyMemoryEditor/macos/process.py
@@ -6,11 +6,13 @@ from typing import Dict, Generator, Optional, Sequence, Tuple, Type, TypeVar, Un
 from ..enums import ScanTypesEnum
 from ..process import AbstractProcess
 from ..process.errors import ClosedProcess
+from ..process.module_info import ModuleInfo
 from ..process.thread_info import ThreadInfo
 from ..util import resolve_bufflength
 
 from .functions import (
     get_memory_regions,
+    get_modules,
     get_task_for_pid,
     get_threads,
     read_process_memory,
@@ -122,6 +124,10 @@ class MacProcess(AbstractProcess):
     def get_threads(self) -> Generator[ThreadInfo, None, None]:
         self.__require_open()
         return get_threads(self.__task)
+
+    def get_modules(self) -> Generator[ModuleInfo, None, None]:
+        self.__require_open()
+        return get_modules(self.__task)
 
     def search_by_addresses(
         self,

--- a/PyMemoryEditor/macos/types.py
+++ b/PyMemoryEditor/macos/types.py
@@ -34,6 +34,9 @@ memory_object_offset_t = c_uint64
 # Region info flavors
 VM_REGION_BASIC_INFO_64 = 9
 
+# task_info() flavor that returns dyld's image-list pointer (mach/task_info.h).
+TASK_DYLD_INFO = 17
+
 # VM protection flags
 VM_PROT_NONE = 0x00
 VM_PROT_READ = 0x01
@@ -68,6 +71,26 @@ class vm_region_basic_info_64(Structure):
 # Number of mach_msg_type_number_t units in vm_region_basic_info_64.
 # Used as the in/out `info_count` parameter to mach_vm_region.
 VM_REGION_BASIC_INFO_COUNT_64 = sizeof(vm_region_basic_info_64) // _NATURAL_T_SIZE
+
+
+class task_dyld_info_data_t(Structure):
+    """Layout of struct task_dyld_info from <mach/task_info.h>.
+
+    ``all_image_info_addr`` is the address, *inside the target task*, of dyld's
+    ``dyld_all_image_infos`` structure — the entry point for enumerating the
+    Mach-O images loaded in the process.
+    """
+
+    _fields_ = [
+        ("all_image_info_addr", mach_vm_address_t),
+        ("all_image_info_size", mach_vm_size_t),
+        ("all_image_info_format", c_int),
+    ]
+
+
+# task_info() reports the buffer length in natural_t (4-byte) units, like
+# mach_vm_region's info_count.
+TASK_DYLD_INFO_COUNT = sizeof(task_dyld_info_data_t) // _NATURAL_T_SIZE
 
 
 class MEMORY_BASIC_INFORMATION(Structure):

--- a/PyMemoryEditor/process/abstract.py
+++ b/PyMemoryEditor/process/abstract.py
@@ -15,6 +15,7 @@ from typing import (
 
 from ..enums import ScanTypesEnum
 from .info import ProcessInfo
+from .module_info import ModuleInfo
 from .scanning import _PRESORTED_KEY
 from .thread_info import ThreadInfo
 
@@ -100,6 +101,24 @@ class AbstractProcess(ABC):
         Linux, DWORD TID on Windows, Mach port name on macOS).
 
         Use :attr:`main_thread` for the conventional "main thread" shortcut.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_modules(self) -> Generator[ModuleInfo, None, None]:
+        """
+        Yield a :class:`~PyMemoryEditor.ModuleInfo` for every module loaded in
+        the target process — the main executable plus each shared library
+        (``.dll`` / ``.so`` / ``.dylib``).
+
+        A module's ``base_address`` is the load address the OS chose for this
+        run; combine it with a static offset (``base_address + offset``) to
+        reach a known location despite ASLR. That sum is the typical
+        ``base_address`` argument to :meth:`resolve_pointer_chain`.
+
+        Each backend fills the ``ModuleInfo`` fields with what its OS surfaces
+        cheaply — see :class:`~PyMemoryEditor.ModuleInfo` for the per-platform
+        meaning of ``raw`` and for when ``size`` may be ``0``.
         """
         raise NotImplementedError()
 

--- a/PyMemoryEditor/process/module_info.py
+++ b/PyMemoryEditor/process/module_info.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+"""
+Cross-platform module descriptor returned by ``AbstractProcess.get_modules()``.
+
+A "module" is a file backing part of the target's address space — the main
+executable plus every shared library loaded into it (``.dll`` on Windows,
+``.so`` on Linux, ``.dylib`` on macOS). The OS places each module at a base
+address that it randomizes per launch (ASLR), but the offsets *inside* a module
+stay constant across runs. ``module.base_address + static_offset`` is therefore
+the portable way to reach a known location regardless of where the loader put
+the module — the natural feed into :meth:`AbstractProcess.resolve_pointer_chain`.
+
+Each backend fills in what its OS exposes cheaply; ``raw`` carries the original
+platform handle/key for advanced follow-up calls.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ModuleInfo:
+    """A single module (executable or shared library) loaded in a process.
+
+    :param name: file name of the module (e.g. ``"game.exe"``, ``"libc.so.6"``).
+    :param path: full path of the backing file on disk when the OS exposes it;
+        falls back to ``name`` when only the name is available.
+    :param base_address: address where the module is loaded for this run — the
+        value to add static offsets to. Defeats ASLR for ``base + offset``
+        addressing.
+    :param size: size of the module in memory, in bytes; ``0`` when the backend
+        cannot determine it. The exact meaning is platform-specific: the full
+        module image on Windows (``modBaseSize``) and Linux (mapped span), but
+        the ``__TEXT`` (code) segment size on macOS, where a single
+        whole-module size is ill-defined for dyld-shared-cache dylibs.
+    :param raw: underlying platform handle/key used to look the module up — the
+        ``MODULEENTRY32.hModule`` on Windows, the mapped path on Linux, the
+        Mach-O load address on macOS. Useful for advanced callers that need to
+        make follow-up OS-specific calls.
+    """
+
+    name: str
+    path: str
+    base_address: int
+    size: int = 0
+    raw: Any = field(default=None, compare=False, repr=False)
+
+
+__all__ = ("ModuleInfo",)

--- a/PyMemoryEditor/win32/functions.py
+++ b/PyMemoryEditor/win32/functions.py
@@ -12,6 +12,7 @@ import logging
 from typing import Dict, Generator, Optional, Sequence, Tuple, Type, TypeVar, Union
 
 from ..enums import ScanTypesEnum
+from ..process.module_info import ModuleInfo
 from ..process.region import enrich_region
 from ..process.scanning import (
     iter_pattern_results,
@@ -31,7 +32,10 @@ from .types import (
     MEMORY_BASIC_INFORMATION,
     MEMORY_BASIC_INFORMATION_32,
     MEMORY_BASIC_INFORMATION_64,
+    MODULEENTRY32,
     SYSTEM_INFO,
+    TH32CS_SNAPMODULE,
+    TH32CS_SNAPMODULE32,
     TH32CS_SNAPTHREAD,
     THREADENTRY32,
 )
@@ -121,6 +125,18 @@ kernel32.Thread32Next.argtypes = (
     ctypes.POINTER(THREADENTRY32),
 )
 kernel32.Thread32Next.restype = ctypes.wintypes.BOOL
+
+kernel32.Module32First.argtypes = (
+    ctypes.wintypes.HANDLE,
+    ctypes.POINTER(MODULEENTRY32),
+)
+kernel32.Module32First.restype = ctypes.wintypes.BOOL
+
+kernel32.Module32Next.argtypes = (
+    ctypes.wintypes.HANDLE,
+    ctypes.POINTER(MODULEENTRY32),
+)
+kernel32.Module32Next.restype = ctypes.wintypes.BOOL
 
 
 system_information = SYSTEM_INFO()
@@ -512,6 +528,58 @@ def GetThreads(pid: int) -> Generator[ThreadInfo, None, None]:
             # time per Microsoft's sample code.
             entry.dwSize = ctypes.sizeof(entry)
             if not kernel32.Thread32Next(snapshot, ctypes.byref(entry)):
+                break
+    finally:
+        kernel32.CloseHandle(snapshot)
+
+
+def GetModules(pid: int) -> Generator[ModuleInfo, None, None]:
+    """
+    Yield a :class:`ModuleInfo` for every module loaded in the target process.
+
+    Uses ``CreateToolhelp32Snapshot(TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32)``
+    followed by Module32First/Next — the documented user-mode way to enumerate
+    modules without an extra dependency. Unlike the thread snapshot, the module
+    snapshot is per-process, so the pid is passed through and honored.
+    ``TH32CS_SNAPMODULE32`` is OR-ed in so a 64-bit Python can still see the
+    32-bit modules of a WOW64 target.
+
+    Module enumeration needs no ``PROCESS_*`` right on the handle — the caller
+    only supplies the pid here.
+    """
+    snapshot = kernel32.CreateToolhelp32Snapshot(
+        TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32, pid
+    )
+    # CreateToolhelp32Snapshot returns INVALID_HANDLE_VALUE (-1 cast to HANDLE)
+    # on failure — same check the thread snapshot uses.
+    if not snapshot or snapshot == ctypes.wintypes.HANDLE(-1).value:
+        _raise_last_error("CreateToolhelp32Snapshot")
+
+    entry = MODULEENTRY32()
+    entry.dwSize = ctypes.sizeof(entry)
+
+    try:
+        if not kernel32.Module32First(snapshot, ctypes.byref(entry)):
+            # Empty snapshot is legal (target exited / not yet initialized).
+            _logger.debug(
+                "GetModules: Module32First returned 0 (snapshot empty for pid=%d)",
+                pid,
+            )
+            return
+
+        while True:
+            # szModule / szExePath are c_char arrays — accessing them returns
+            # the NUL-terminated bytes directly.
+            name = entry.szModule.decode("utf-8", errors="replace")
+            path = entry.szExePath.decode("utf-8", errors="replace")
+            yield ModuleInfo(
+                name=name,
+                path=path or name,
+                base_address=int(entry.modBaseAddr or 0),
+                size=int(entry.modBaseSize),
+                raw=int(entry.hModule or 0),
+            )
+            if not kernel32.Module32Next(snapshot, ctypes.byref(entry)):
                 break
     finally:
         kernel32.CloseHandle(snapshot)

--- a/PyMemoryEditor/win32/process.py
+++ b/PyMemoryEditor/win32/process.py
@@ -8,12 +8,14 @@ from ..util import resolve_bufflength
 from ..enums import ScanTypesEnum
 from ..process import AbstractProcess
 from ..process.errors import ClosedProcess
+from ..process.module_info import ModuleInfo
 from ..process.thread_info import ThreadInfo
 from .enums import ProcessOperationsEnum
 
 from .functions import (
     CloseProcessHandle,
     GetMemoryRegions,
+    GetModules,
     GetProcessHandle,
     GetThreads,
     ReadProcessMemory,
@@ -161,6 +163,11 @@ class WindowsProcess(AbstractProcess):
         self.__require_open()
         # Toolhelp32 takes a PID, not a handle — no PROCESS_* right needed.
         return GetThreads(self.pid)
+
+    def get_modules(self) -> Generator[ModuleInfo, None, None]:
+        self.__require_open()
+        # The Toolhelp32 module snapshot takes a PID, not a handle.
+        return GetModules(self.pid)
 
     def search_by_addresses(
         self,

--- a/PyMemoryEditor/win32/types.py
+++ b/PyMemoryEditor/win32/types.py
@@ -2,6 +2,7 @@
 
 from ctypes import (
     Structure,
+    c_char,
     c_ulonglong,
     c_void_p,
     sizeof,
@@ -78,4 +79,38 @@ class THREADENTRY32(Structure):
         ("tpBasePri", wintypes.LONG),
         ("tpDeltaPri", wintypes.LONG),
         ("dwFlags", wintypes.DWORD),
+    ]
+
+
+# CreateToolhelp32Snapshot flags for module enumeration — used by get_modules().
+# TH32CS_SNAPMODULE32 is OR-ed in so a 64-bit caller can also see the 32-bit
+# modules of a WOW64 target.
+TH32CS_SNAPMODULE = 0x00000008
+TH32CS_SNAPMODULE32 = 0x00000010
+
+# Fixed buffer sizes from <tlhelp32.h> / <minwindef.h>.
+MAX_MODULE_NAME32 = 255
+MAX_PATH = 260
+
+
+class MODULEENTRY32(Structure):
+    """Layout matching the ANSI Win32 ``MODULEENTRY32`` (Module32First/Next).
+
+    ``modBaseAddr`` is declared as a void pointer so it stays pointer-sized on
+    both 32- and 64-bit builds; read it as an int via ``entry.modBaseAddr``.
+    ``szModule`` / ``szExePath`` are ``c_char`` arrays — accessing them yields
+    the NUL-terminated bytes directly.
+    """
+
+    _fields_ = [
+        ("dwSize", wintypes.DWORD),
+        ("th32ModuleID", wintypes.DWORD),
+        ("th32ProcessID", wintypes.DWORD),
+        ("GlblcntUsage", wintypes.DWORD),
+        ("ProccntUsage", wintypes.DWORD),
+        ("modBaseAddr", c_void_p),
+        ("modBaseSize", wintypes.DWORD),
+        ("hModule", wintypes.HMODULE),
+        ("szModule", c_char * (MAX_MODULE_NAME32 + 1)),
+        ("szExePath", c_char * MAX_PATH),
     ]

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ reading, writing and searching values in the process memory.
 | **Scan modes** | Exact, not-exact, bigger / smaller (±equal), in-range, out-of-range. |
 | **Pattern scan** | Byte signatures or regex — `grep` for process memory. |
 | **Pointer chains** | Walk multi-level pointers (`[[base+0x10]+0x20]+0x30`) in one call. |
+| **Module enumeration** | List loaded executables & libraries with their base address — `base + offset` beats ASLR. |
 | **Snapshot caching** | The Cheat-Engine "scan → refine → refine" loop, accelerated. |
 | **Bundled GUI app** | A full memory scanner ships in the box — just type `pymemoryeditor`. |
 
@@ -256,6 +257,25 @@ address, size and metadata of every region the target owns:
 for region in process.get_memory_regions():
     print(hex(region["address"]), region["size"], region["struct"])
 ```
+
+### 📦 Listing the loaded modules
+
+A *module* is a file mapped into the process — the main executable plus every
+shared library it loaded (`.exe`/`.dll` on Windows, the binary and `.so` files
+on Linux, the Mach-O image and `.dylib` files on macOS). `get_modules()` yields
+a `ModuleInfo` for each one:
+
+```python
+for module in process.get_modules():
+    print(
+        module.name,
+        hex(module.base_address), 
+        module.size,
+        module.path
+    )
+    ...
+```
+
 
 ### 🧵 Listing the process threads
 

--- a/tests/test_app_smoke.py
+++ b/tests/test_app_smoke.py
@@ -64,6 +64,7 @@ def test_app_modules_import_cleanly():
     import PyMemoryEditor.app.cheat_table  # noqa: F401
     import PyMemoryEditor.app.memory_viewer_dialog  # noqa: F401
     import PyMemoryEditor.app.memory_map_dialog  # noqa: F401
+    import PyMemoryEditor.app.modules_dialog  # noqa: F401
     import PyMemoryEditor.app.open_process_dialog  # noqa: F401
     import PyMemoryEditor.app.main_window  # noqa: F401
     import PyMemoryEditor.app.application  # noqa: F401

--- a/tests/test_module_enumeration.py
+++ b/tests/test_module_enumeration.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+
+"""
+Cross-platform tests for ``AbstractProcess.get_modules`` and the ``ModuleInfo``
+descriptor. Everything runs against the test process itself (``os.getpid()``),
+which always has at least the interpreter plus its standard libraries loaded,
+so the enumeration has something concrete to find on every platform.
+"""
+
+import os
+import sys
+
+import pytest
+
+if sys.platform not in ("win32", "darwin") and not sys.platform.startswith("linux"):
+    pytest.skip("Platform not supported by PyMemoryEditor", allow_module_level=True)
+
+
+from PyMemoryEditor import ModuleInfo, OpenProcess  # noqa: E402
+
+
+@pytest.fixture
+def modules():
+    """Materialize the current process's module list once per test."""
+    with OpenProcess(pid=os.getpid()) as process:
+        return list(process.get_modules())
+
+
+def test_get_modules_returns_module_infos(modules):
+    """Each yielded item must be a well-formed ``ModuleInfo``."""
+    assert modules, "expected at least one loaded module"
+    for module in modules:
+        assert isinstance(module, ModuleInfo)
+        assert isinstance(module.name, str)
+        assert isinstance(module.path, str)
+        assert isinstance(module.base_address, int)
+        assert isinstance(module.size, int)
+
+
+def test_get_modules_finds_more_than_one(modules):
+    """A live Python process loads its executable plus several shared libs."""
+    assert len(modules) > 1, "expected the interpreter + its libraries, got %d" % len(
+        modules
+    )
+
+
+def test_module_base_addresses_are_positive(modules):
+    """The loader never maps a real module at address 0."""
+    for module in modules:
+        assert module.base_address > 0, "module %r has a zero base address" % (
+            module.name,
+        )
+
+
+def test_module_sizes_are_non_negative(modules):
+    """``size`` is a byte count — never negative."""
+    for module in modules:
+        assert module.size >= 0, "module %r has a negative size" % (module.name,)
+
+
+def test_module_base_addresses_are_unique(modules):
+    """Each module occupies its own load address; none should collide."""
+    bases = [module.base_address for module in modules]
+    assert len(bases) == len(set(bases)), "two modules share a base address"
+
+
+def test_interpreter_module_is_present(modules):
+    """
+    Running the suite under CPython, *some* loaded module must reference
+    Python — the interpreter binary itself and/or ``libpython`` (the name and
+    casing differ per platform, so we match a lowercase substring on both name
+    and path).
+    """
+    haystack = " ".join((m.name + " " + m.path) for m in modules).lower()
+    assert "python" in haystack, "no python-related module found in the enumeration"
+
+
+def test_module_base_matches_a_real_memory_region():
+    """
+    A module's ``base_address`` is the start of one of the process's memory
+    regions — cross-checking the two enumerations guards against a backend
+    returning bogus / unaligned bases.
+    """
+    with OpenProcess(pid=os.getpid()) as process:
+        modules = list(process.get_modules())
+        region_starts = {region["address"] for region in process.get_memory_regions()}
+
+    matched = sum(1 for m in modules if m.base_address in region_starts)
+    assert matched > 0, (
+        "no module base_address lined up with a memory-region start "
+        "(checked %d modules against %d regions)"
+        % (len(modules), len(region_starts))
+    )
+
+
+def test_module_info_is_hashable_and_comparable():
+    """``ModuleInfo`` is a frozen dataclass — usable as dict keys / set members."""
+    a = ModuleInfo(name="game.exe", path="/x/game.exe", base_address=0x1000, size=4096)
+    b = ModuleInfo(name="game.exe", path="/x/game.exe", base_address=0x1000, size=4096)
+    c = ModuleInfo(name="other.so", path="/x/other.so", base_address=0x2000, size=8192)
+
+    assert a == b
+    assert a != c
+
+    # ``raw`` is excluded from equality (compare=False), so two entries from
+    # different snapshots that otherwise match still compare equal.
+    d = ModuleInfo(name="game.exe", path="/x/game.exe", base_address=0x1000, raw="h1")
+    e = ModuleInfo(name="game.exe", path="/x/game.exe", base_address=0x1000, raw="h2")
+    assert d == e
+
+    # And hashable (frozen=True):
+    {a, b, c}
+
+
+def test_module_info_size_defaults_to_zero():
+    """``size`` is optional and defaults to 0 for backends that can't fill it."""
+    module = ModuleInfo(name="x", path="/x", base_address=0x10)
+    assert module.size == 0
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="Linux-specific: modules are file-backed mappings from /proc/<pid>/maps",
+)
+def test_linux_modules_are_absolute_paths_with_libc(modules):
+    """On Linux every module is a real file (absolute path) and libc is loaded."""
+    for module in modules:
+        assert module.path.startswith("/"), "module path is not absolute: %r" % (
+            module.path,
+        )
+        assert module.name == os.path.basename(module.path)
+
+    names = " ".join(m.name for m in modules).lower()
+    assert "libc" in names, "expected libc to be among the loaded modules"
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Windows-specific: the main module is an .exe and kernel32 is loaded",
+)
+def test_windows_modules_include_exe_and_kernel32(modules):
+    """On Windows the process executable and kernel32.dll are always present."""
+    names = [m.name.lower() for m in modules]
+    assert any(n.endswith(".exe") for n in names), "no .exe module found"
+    assert any("kernel32" in n for n in names), "kernel32.dll not enumerated"
+
+
+@pytest.mark.skipif(
+    sys.platform != "darwin",
+    reason="macOS-specific: dyld images include libsystem; size is the __TEXT span",
+)
+def test_macos_modules_include_libsystem_with_text_size(modules):
+    """On macOS libsystem is loaded and at least one module reports a __TEXT size."""
+    names = " ".join(m.name for m in modules).lower()
+    assert "libsystem" in names, "expected libSystem among the dyld images"
+    assert any(m.size > 0 for m in modules), "no module reported a non-zero __TEXT size"


### PR DESCRIPTION
Add cross-platform module enumeration: ModuleInfo descriptor, an abstract get_modules() on AbstractProcess, and backend implementations:

- Linux: groups file-backed mappings from /proc/<pid>/maps by path.
- Windows: Toolhelp32 Module32First/Next (TH32CS_SNAPMODULE | ..._32 for WOW64 targets).
- macOS: walks dyld_all_image_infos via task_info(TASK_DYLD_INFO); size is the __TEXT segment (whole-module size is ill-defined for shared-cache dylibs).

Each ModuleInfo carries name, path, base_address, size and raw. The base address feeds base+offset addressing and resolve_pointer_chain to beat ASLR.

Also expose ModuleInfo from the package root, add a Modules dialog to the GUI app (filterable table, copy base address, open in hex viewer), document the feature in the README, and add tests.

**Why is this PR necessary, what does it do?**

<!-- 
IMPORTANT! Explain the **motivation** for making this change: what existing
problem the pull request solves or what new features it implements.
-->

**Checklist (complete all items)**:

- [ ] Added tests as necessary.
- [ ] There is no breaking change for existing features.

**References:**

<!-- (Nice to have) 
Link tasks, issues, PRs that are related to this pull request, etc. 
-->

No references to be shared. 

**Notes:**

<!-- (Optional) 
Explain some changes that can be useful when reviewing this pull request. 
-->

No notes to be shared. 