### PR TITLE
feat: implement RemotePointer - live pointer handle with arithmetic

### DIFF
--- a/PyMemoryEditor/__init__.py
+++ b/PyMemoryEditor/__init__.py
@@ -24,6 +24,7 @@ from .process.errors import (
     PyMemoryEditorError,
 )
 from .process.module_info import ModuleInfo
+from .process.remote_pointer import RemotePointer
 from .process.thread_info import ThreadInfo
 
 
@@ -87,6 +88,7 @@ __all__ = (
     "ProcessIDNotExistsError",
     "ProcessNotFoundError",
     "PyMemoryEditorError",
+    "RemotePointer",
     "ScanTypesEnum",
     "ThreadInfo",
     "__author__",

--- a/PyMemoryEditor/process/__init__.py
+++ b/PyMemoryEditor/process/__init__.py
@@ -4,3 +4,4 @@ from . import errors
 from . import util
 from .abstract import AbstractProcess
 from .info import ProcessInfo
+from .remote_pointer import RemotePointer

--- a/PyMemoryEditor/process/abstract.py
+++ b/PyMemoryEditor/process/abstract.py
@@ -10,6 +10,7 @@ from typing import (
     Tuple,
     Type,
     TypeVar,
+    TYPE_CHECKING,
     Union,
 )
 
@@ -18,6 +19,9 @@ from .info import ProcessInfo
 from .module_info import ModuleInfo
 from .scanning import _PRESORTED_KEY
 from .thread_info import ThreadInfo
+
+if TYPE_CHECKING:
+    from .remote_pointer import RemotePointer
 
 
 T = TypeVar("T")
@@ -348,6 +352,42 @@ class AbstractProcess(ABC):
         :raises NotImplementedError: on Linux (see :meth:`allocate_memory`).
         """
         raise NotImplementedError()
+
+    def get_pointer(
+        self,
+        base_address: int,
+        offsets: Optional[Sequence[int]] = None,
+        *,
+        pytype: Type = int,
+        bufflength: Optional[int] = None,
+        ptr_size: int = 8,
+    ) -> "RemotePointer":
+        """
+        Build a :class:`~PyMemoryEditor.RemotePointer` bound to this process —
+        a live, re-resolving handle to a typed value in the target.
+
+        Convenience wrapper around the ``RemotePointer(self, ...)`` constructor;
+        see that class for the meaning of every parameter (notably ``offsets``,
+        whose ``None`` vs ``[]`` distinction selects a direct handle vs a
+        single-dereference chain).
+
+        Example
+        -------
+        ::
+
+            hp = process.get_pointer(0x14010F4F4, [0x0, 0x158], pytype=int, bufflength=4)
+            hp.value -= 10
+        """
+        from .remote_pointer import RemotePointer
+
+        return RemotePointer(
+            self,
+            base_address,
+            offsets,
+            pytype=pytype,
+            bufflength=bufflength,
+            ptr_size=ptr_size,
+        )
 
     def resolve_pointer_chain(
         self,

--- a/PyMemoryEditor/process/remote_pointer.py
+++ b/PyMemoryEditor/process/remote_pointer.py
@@ -22,7 +22,7 @@ Because it is built purely on the abstract ``read_process_memory`` /
 on Windows, Linux and macOS.
 """
 
-from typing import Optional, Sequence, Type, TypeVar, TYPE_CHECKING, Union
+from typing import Optional, Sequence, Tuple, Type, TypeVar, TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     from .abstract import AbstractProcess
@@ -180,6 +180,7 @@ class RemotePointer:
         re-walks the chain on every access — ``(hp + 4)`` keeps following the
         target as it moves, it doesn't snapshot the address at shift time.
         """
+        new_offsets: Optional[Tuple[int, ...]]
         if self._offsets is None:
             # Direct handle: just move the base address.
             new_base, new_offsets = self._base_address + delta, None

--- a/PyMemoryEditor/process/remote_pointer.py
+++ b/PyMemoryEditor/process/remote_pointer.py
@@ -1,0 +1,239 @@
+# -*- coding: utf-8 -*-
+
+"""
+Live handle to a value living in another process's address space.
+
+A :class:`RemotePointer` bundles together the three things you otherwise have
+to carry by hand on every access — the process, *where* the value lives, and
+*how* to interpret the bytes there — behind a single ``.value`` property::
+
+    hp = RemotePointer(process, 0x14010F4F4, [0x0, 0x158], pytype=int, bufflength=4)
+    print(hp.value)   # read
+    hp.value = 9999   # write
+
+The win over a bare ``read_process_memory`` call is that a pointer **re-resolves
+its address on every access**. When ``offsets`` is given, each ``.value`` read
+walks the chain again with :meth:`AbstractProcess.resolve_pointer_chain`, so the
+handle keeps working even as the target moves its objects around the heap — the
+same reason a Cheat Engine pointer entry survives a level reload.
+
+Because it is built purely on the abstract ``read_process_memory`` /
+``write_process_memory`` / ``resolve_pointer_chain`` API, it behaves identically
+on Windows, Linux and macOS.
+"""
+
+from typing import Optional, Sequence, Type, TypeVar, TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    from .abstract import AbstractProcess
+
+
+T = TypeVar("T")
+
+
+class RemotePointer:
+    """A re-resolving, read/write handle to a typed value in a target process.
+
+    :param process: the open process the value lives in (any ``OpenProcess``
+        backend).
+    :param base_address: starting address. For a direct handle this is the
+        address of the value itself; for a pointer chain it is typically
+        ``module_base + static_offset``.
+    :param offsets: how to reach the value from ``base_address``:
+
+        * ``None`` (default) — **direct handle**: ``address`` *is*
+          ``base_address``, with no dereferencing. Use this to wrap an address
+          you already found (e.g. from :meth:`AbstractProcess.search_by_value`).
+        * a sequence (including the empty list ``[]``) — the value sits at the
+          end of a pointer chain. ``address`` is recomputed on every access via
+          :meth:`AbstractProcess.resolve_pointer_chain`, so the same chain
+          semantics apply: ``[]`` dereferences ``base_address`` once; a
+          non-empty list walks each offset, dereferencing all but the last.
+
+    :param pytype: how to interpret the bytes at the resolved address (bool,
+        int, float, str or bytes). Defaults to ``int``.
+    :param bufflength: value size in bytes. May be ``None`` for numeric types
+        (defaults: int→4, float→8, bool→1); ``str`` and ``bytes`` require an
+        explicit size.
+    :param ptr_size: pointer width used when walking ``offsets`` — 8 for 64-bit
+        targets (default), 4 for 32-bit. Ignored for a direct handle.
+
+    Example
+    -------
+    Cheat-table entry ``"game.exe"+0x10F4F4 -> [+0x0] -> [+0x158]`` (HP)::
+
+        module = next(m for m in process.get_modules() if m.name == "game.exe")
+        hp = RemotePointer(
+            process, module.base_address + 0x10F4F4, [0x0, 0x158],
+            pytype=int, bufflength=4,
+        )
+        hp.value -= 10        # take 10 damage, wherever the object moved to
+    """
+
+    def __init__(
+        self,
+        process: "AbstractProcess",
+        base_address: int,
+        offsets: Optional[Sequence[int]] = None,
+        *,
+        pytype: Type = int,
+        bufflength: Optional[int] = None,
+        ptr_size: int = 8,
+    ):
+        self._process = process
+        self._base_address = base_address
+        # Materialize the sequence so later mutation of a caller-held list can't
+        # silently change where this pointer resolves. ``None`` is preserved as
+        # the "direct handle" sentinel and kept distinct from an empty chain.
+        self._offsets = None if offsets is None else tuple(offsets)
+        self._pytype = pytype
+        self._bufflength = bufflength
+        self._ptr_size = ptr_size
+
+    @property
+    def process(self) -> "AbstractProcess":
+        """The process this pointer reads from / writes to."""
+        return self._process
+
+    @property
+    def base_address(self) -> int:
+        """The starting address the pointer was built with."""
+        return self._base_address
+
+    @property
+    def offsets(self) -> Optional[Sequence[int]]:
+        """The pointer-chain offsets, or ``None`` for a direct handle."""
+        return self._offsets
+
+    @property
+    def address(self) -> int:
+        """
+        The address the value currently lives at.
+
+        For a direct handle this is ``base_address`` unchanged. For a pointer
+        chain it is recomputed on every read of this property by walking the
+        chain — so each access reflects where the target's pointers point *now*.
+        """
+        if self._offsets is None:
+            return self._base_address
+        return self._process.resolve_pointer_chain(
+            self._base_address, self._offsets, ptr_size=self._ptr_size
+        )
+
+    @property
+    def value(self):
+        """Read and return the value at :attr:`address` using the bound type."""
+        return self._process.read_process_memory(
+            self.address, self._pytype, self._bufflength
+        )
+
+    @value.setter
+    def value(self, new_value: Union[bool, int, float, str, bytes]) -> None:
+        """Write ``new_value`` to :attr:`address` using the bound type."""
+        self._process.write_process_memory(
+            self.address, self._pytype, self._bufflength, new_value
+        )
+
+    def read(
+        self,
+        pytype: Optional[Type[T]] = None,
+        bufflength: Optional[int] = None,
+    ) -> T:
+        """
+        Read the value at :attr:`address`, optionally overriding the bound type.
+
+        Lets a single pointer be reinterpreted ad hoc (e.g. peek the same
+        address as ``bytes``) without building a second handle. Falls back to
+        the type and size the pointer was constructed with.
+        """
+        return self._process.read_process_memory(
+            self.address,
+            self._pytype if pytype is None else pytype,
+            self._bufflength if bufflength is None else bufflength,
+        )
+
+    def write(
+        self,
+        value: Union[bool, int, float, str, bytes],
+        pytype: Optional[Type] = None,
+        bufflength: Optional[int] = None,
+    ) -> Union[bool, int, float, str, bytes]:
+        """
+        Write ``value`` to :attr:`address`, optionally overriding the bound type.
+
+        Mirrors :meth:`read`; returns whatever ``write_process_memory`` returns.
+        """
+        return self._process.write_process_memory(
+            self.address,
+            self._pytype if pytype is None else pytype,
+            self._bufflength if bufflength is None else bufflength,
+            value,
+        )
+
+    def _shift(self, delta: int) -> "RemotePointer":
+        """
+        Return a new pointer whose resolved address is this one's ``+ delta``,
+        carrying over ``pytype`` / ``bufflength`` / ``ptr_size`` unchanged.
+
+        The shift is folded into the address arithmetic *lazily*: for a pointer
+        chain it is added to the final offset, so the returned pointer still
+        re-walks the chain on every access — ``(hp + 4)`` keeps following the
+        target as it moves, it doesn't snapshot the address at shift time.
+        """
+        if self._offsets is None:
+            # Direct handle: just move the base address.
+            new_base, new_offsets = self._base_address + delta, None
+        elif len(self._offsets) == 0:
+            # offsets=[] dereferences base once; +delta means deref then +delta,
+            # which is exactly the chain [delta].
+            new_base, new_offsets = self._base_address, (delta,)
+        else:
+            # Adding to the final address == adding to the last (non-deref) hop.
+            new_base = self._base_address
+            new_offsets = self._offsets[:-1] + (self._offsets[-1] + delta,)
+
+        return RemotePointer(
+            self._process,
+            new_base,
+            new_offsets,
+            pytype=self._pytype,
+            bufflength=self._bufflength,
+            ptr_size=self._ptr_size,
+        )
+
+    def __add__(self, delta: int) -> "RemotePointer":
+        """C-style pointer arithmetic: a new pointer ``delta`` bytes ahead.
+
+        Does **not** touch memory — to change the stored value use ``.value``
+        (e.g. ``ptr.value += 10``).
+        """
+        if not isinstance(delta, int):
+            return NotImplemented
+        return self._shift(delta)
+
+    __radd__ = __add__  # support ``offset + ptr`` as well as ``ptr + offset``
+
+    def __sub__(self, other: Union[int, "RemotePointer"]) -> Union[int, "RemotePointer"]:
+        """``ptr - n`` → a pointer ``n`` bytes behind; ``ptr - other`` → the
+        byte distance between the two resolved addresses (like C pointers).
+        """
+        if isinstance(other, RemotePointer):
+            return self.address - other.address
+        if not isinstance(other, int):
+            return NotImplemented
+        return self._shift(-other)
+
+    def __int__(self) -> int:
+        """The resolved :attr:`address` — handy for arithmetic and logging."""
+        return self.address
+
+    def __repr__(self) -> str:
+        chain = "" if self._offsets is None else " -> %r" % (list(self._offsets),)
+        return "<RemotePointer base=0x%X%s pytype=%s>" % (
+            self._base_address,
+            chain,
+            getattr(self._pytype, "__name__", self._pytype),
+        )
+
+
+__all__ = ("RemotePointer",)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ reading, writing and searching values in the process memory.
 | **Scan modes** | Exact, not-exact, bigger / smaller (±equal), in-range, out-of-range. |
 | **Pattern scan** | Byte signatures or regex — `grep` for process memory. |
 | **Pointer chains** | Walk multi-level pointers (`[[base+0x10]+0x20]+0x30`) in one call. |
+| **Live pointers** | A `RemotePointer` handle re-resolves its chain on every `.value` read/write. |
 | **Module enumeration** | List loaded executables & libraries with their base address — `base + offset` beats ASLR. |
 | **Allocate / free memory** | Reserve and release memory inside the target (Windows & macOS). |
 | **Snapshot caching** | The Cheat-Engine "scan → refine → refine" loop, accelerated. |
@@ -333,6 +334,31 @@ hp = process.read_process_memory(hp_address, int, 4)
 ```
 
 `ptr_size=4` for 32-bit targets, `ptr_size=8` (default) for 64-bit.
+
+### 📍 Live pointers — a handle you keep around
+
+`resolve_pointer_chain` finds an address once. A **`RemotePointer`** wraps that
+recipe in a reusable handle: read or write the value through `.value`, and it
+re-walks the chain every time — so the same handle keeps working even when the
+target moves things around in memory.
+
+```python
+# A handle to the player's HP, behind a two-level pointer.
+hp_ptr = process.get_pointer(address, pytype=int, bufflength=4)
+
+print(hp_ptr.value)   # read it
+hp_ptr.value = 9999   # write it
+```
+
+You can do pointer math too: `hp_ptr + 4` gives a **new** handle 4 bytes further
+along (handy when values sit side by side), without touching memory. Omit the
+offsets to wrap an address you already have — e.g. one found by a scan.
+
+```python
+# Mana is stored right after HP, so just step 4 bytes forward.
+mp_ptr = hp_ptr + 4
+print(mp_ptr.value)
+```
 
 ### 🧱 Allocating memory in the target
 

--- a/tests/test_remote_pointer.py
+++ b/tests/test_remote_pointer.py
@@ -1,0 +1,211 @@
+# -*- coding: utf-8 -*-
+
+"""
+Tests for :class:`PyMemoryEditor.RemotePointer` and the ``process.get_pointer()``
+factory. Builds ctypes objects on the test's own heap and verifies that the
+handle reads, writes and — crucially — re-resolves its address through a
+pointer chain on every access, the way a Cheat Engine pointer entry does.
+"""
+
+import ctypes
+import os
+import sys
+
+import pytest
+
+if sys.platform not in ("win32", "darwin") and not sys.platform.startswith("linux"):
+    pytest.skip("Platform not supported by PyMemoryEditor", allow_module_level=True)
+
+
+from PyMemoryEditor import OpenProcess, RemotePointer  # noqa: E402
+
+
+@pytest.fixture
+def process():
+    handle = OpenProcess(pid=os.getpid())
+    try:
+        yield handle
+    finally:
+        handle.close()
+
+
+def test_direct_handle_reads_value(process):
+    """offsets=None -> address is base_address, no dereference."""
+    target = ctypes.c_int32(0x1234)
+    ptr = RemotePointer(process, ctypes.addressof(target), pytype=int, bufflength=4)
+
+    assert ptr.address == ctypes.addressof(target)
+    assert ptr.value == 0x1234
+    assert int(ptr) == ctypes.addressof(target)
+
+
+def test_direct_handle_writes_value(process):
+    """Writing .value updates the underlying memory."""
+    target = ctypes.c_int32(0)
+    ptr = process.get_pointer(ctypes.addressof(target), pytype=int, bufflength=4)
+
+    ptr.value = 0x7FABCDEF
+    assert target.value == 0x7FABCDEF
+
+
+def test_value_setter_round_trips(process):
+    target = ctypes.c_int32(5)
+    ptr = process.get_pointer(ctypes.addressof(target), pytype=int, bufflength=4)
+
+    ptr.value -= 10
+    assert target.value == -5
+    assert ptr.value == -5
+
+
+def test_chain_resolves_through_pointer(process):
+    """A non-empty offsets list walks the chain like resolve_pointer_chain."""
+    target = ctypes.c_int32(0x22222222)
+    holder = ctypes.c_uint64(ctypes.addressof(target))
+
+    # [0x4] would point past; use [0x0] to land on target via one dereference.
+    ptr = process.get_pointer(
+        ctypes.addressof(holder), [0x0], pytype=int, bufflength=4
+    )
+
+    assert ptr.address == ctypes.addressof(target)
+    assert ptr.value == 0x22222222
+
+
+def test_chain_reresolves_on_each_access(process):
+    """
+    The whole point of the handle: when the intermediate pointer is changed to
+    aim at a different object, the *same* RemotePointer follows it without being
+    rebuilt.
+    """
+    first = ctypes.c_int32(111)
+    second = ctypes.c_int32(222)
+    holder = ctypes.c_uint64(ctypes.addressof(first))
+
+    ptr = process.get_pointer(
+        ctypes.addressof(holder), [0x0], pytype=int, bufflength=4
+    )
+    assert ptr.value == 111
+
+    # Repoint the holder at the second object; the handle must follow.
+    holder.value = ctypes.addressof(second)
+    assert ptr.address == ctypes.addressof(second)
+    assert ptr.value == 222
+
+
+def test_empty_offsets_dereferences_once(process):
+    """offsets=[] keeps resolve_pointer_chain semantics: one dereference."""
+    target = ctypes.c_int32(0x5A5A5A5A)
+    holder = ctypes.c_uint64(ctypes.addressof(target))
+
+    ptr = process.get_pointer(ctypes.addressof(holder), [], pytype=int, bufflength=4)
+
+    assert ptr.address == ctypes.addressof(target)
+    assert ptr.value == 0x5A5A5A5A
+
+
+def test_read_override_reinterprets_bytes(process):
+    """read() can reinterpret the same address under a different type."""
+    target = ctypes.c_int32(0x41424344)
+    ptr = process.get_pointer(ctypes.addressof(target), pytype=int, bufflength=4)
+
+    raw = ptr.read(bytes, 4)
+    assert raw == bytes(ctypes.string_at(ctypes.addressof(target), 4))
+
+
+def test_offsets_are_copied_not_aliased(process):
+    """Mutating the caller's list after construction must not move the pointer."""
+    target = ctypes.c_int32(7)
+    holder = ctypes.c_uint64(ctypes.addressof(target))
+    offsets = [0x0]
+
+    ptr = process.get_pointer(
+        ctypes.addressof(holder), offsets, pytype=int, bufflength=4
+    )
+    offsets.append(0x999)  # must not affect the already-built pointer
+
+    assert ptr.value == 7
+
+
+def test_factory_returns_remote_pointer(process):
+    target = ctypes.c_int32(1)
+    ptr = process.get_pointer(ctypes.addressof(target))
+    assert isinstance(ptr, RemotePointer)
+    assert ptr.process is process
+
+
+def test_add_returns_shifted_pointer_without_touching_memory(process):
+    """ptr + n is a new pointer n bytes ahead; the original is unchanged."""
+    pair = (ctypes.c_int32 * 2)(0x11111111, 0x22222222)
+    base = ctypes.addressof(pair)
+    ptr = process.get_pointer(base, pytype=int, bufflength=4)
+
+    shifted = ptr + 4
+    assert isinstance(shifted, RemotePointer)
+    assert shifted is not ptr
+    assert shifted.address == base + 4
+    assert shifted.value == 0x22222222
+
+    # Original pointer untouched, and memory was never written.
+    assert ptr.address == base
+    assert ptr.value == 0x11111111
+
+
+def test_radd_is_symmetric(process):
+    target = ctypes.c_int32(0)
+    base = ctypes.addressof(target)
+    ptr = process.get_pointer(base)
+    assert (8 + ptr).address == base + 8
+
+
+def test_sub_int_shifts_backwards(process):
+    pair = (ctypes.c_int32 * 2)(0xAAAAAAA, 0x22222222)
+    base = ctypes.addressof(pair)
+    second = process.get_pointer(base + 4, pytype=int, bufflength=4)
+
+    first = second - 4
+    assert first.address == base
+    assert first.value == 0xAAAAAAA
+
+
+def test_sub_pointer_returns_byte_distance(process):
+    pair = (ctypes.c_int32 * 2)(0, 0)
+    base = ctypes.addressof(pair)
+    a = process.get_pointer(base)
+    b = process.get_pointer(base + 12)
+    assert b - a == 12
+    assert a - b == -12
+
+
+def test_arithmetic_preserves_type_metadata(process):
+    target = ctypes.c_int32(0x41424344)
+    ptr = process.get_pointer(ctypes.addressof(target), pytype=bytes, bufflength=4)
+    shifted = ptr - 0  # no-op shift, but must keep pytype/bufflength
+    assert shifted.read() == ptr.read()
+    assert isinstance(shifted.value, bytes)
+
+
+def test_add_shifts_chain_lazily(process):
+    """
+    Shifting a pointer chain must keep re-resolving: moving the intermediate
+    pointer still moves where (ptr + 4) lands.
+    """
+    first = (ctypes.c_int32 * 2)(0x111, 0x222)
+    second = (ctypes.c_int32 * 2)(0x333, 0x444)
+    holder = ctypes.c_uint64(ctypes.addressof(first))
+
+    base_ptr = process.get_pointer(
+        ctypes.addressof(holder), [0x0], pytype=int, bufflength=4
+    )
+    shifted = base_ptr + 4  # second int of whatever the holder points at
+
+    assert shifted.value == 0x222
+
+    # Repoint the holder; the shifted pointer must follow to second[+4].
+    holder.value = ctypes.addressof(second)
+    assert shifted.value == 0x444
+
+
+def test_add_rejects_non_int(process):
+    ptr = process.get_pointer(0x1000)
+    with pytest.raises(TypeError):
+        ptr + 1.5


### PR DESCRIPTION
## What

Adds **`RemotePointer`**, a reusable handle to a typed value in the target process — the missing ergonomic layer on top of `resolve_pointer_chain`.

- Read/write the value through `.value`; the chain is **re-walked on every access**, so the handle survives the target moving its objects (ASLR / heap reallocation), the same way a Cheat Engine pointer entry survives a level reload.
- **C-style pointer arithmetic:** `ptr + n` / `ptr - n` return a *new* handle shifted by `n` bytes (lazily, without touching memory); `ptr - other_ptr` returns the byte distance between two resolved addresses.
- `offsets` semantics mirror `resolve_pointer_chain`: `None` → direct handle, `[]` → one dereference, non-empty list → walk the chain.

## API

- New class `PyMemoryEditor.RemotePointer`.
- New factory `process.get_pointer(base_address, offsets=None, *, pytype=int, bufflength=None, ptr_size=8)`.

## Why

Pure Python over the abstract `read_process_memory` / `write_process_memory` / `resolve_pointer_chain` API, so it works **identically on Windows, Linux and macOS** — closing a gap against Windows-only libraries while keeping cross-platform parity.

## Tests

16 tests in `tests/test_remote_pointer.py` covering direct handles, chain resolution, lazy re-resolution, value read/write, type overrides, and the arithmetic operators.

## Docs

New beginner-friendly "Live pointers" section in the README plus a Highlights row.