### PR TITLE
refactor: unify region filters across backends + worker/test cleanup

### DIFF
--- a/PyMemoryEditor/app/cheat_table.py
+++ b/PyMemoryEditor/app/cheat_table.py
@@ -94,9 +94,24 @@ class CheatTable(QWidget):
         self._publish_timer.timeout.connect(self._publish_snapshot_to_worker)
         self._publish_timer.start()
 
-    def closeEvent(self, event):  # noqa: N802 — Qt naming
+    def shutdown(self) -> None:
+        """
+        Stop the cheat poller thread cleanly.
+
+        Idempotent and safe to call from places ``closeEvent`` won't fire —
+        ``QWidget.deleteLater()`` / ``setParent(None)`` do *not* trigger
+        ``closeEvent``, so ``_change_process`` and the top-level window's
+        ``closeEvent`` need to drive the teardown explicitly to avoid leaving
+        the poller running against a now-closed process handle.
+        """
+        # Stop the publish timer first so no fresh snapshot races our shutdown.
+        if self._publish_timer.isActive():
+            self._publish_timer.stop()
         self._poller.stop()
         self._poller.wait(1000)
+
+    def closeEvent(self, event):  # noqa: N802 — Qt naming
+        self.shutdown()
         super().closeEvent(event)
 
     def _build_ui(self) -> None:

--- a/PyMemoryEditor/app/main_window.py
+++ b/PyMemoryEditor/app/main_window.py
@@ -806,6 +806,14 @@ class MainWindow(QMainWindow):
         # Replace the cheat table — old entries point at the previous process.
         # QSplitter has no QLayout, so we use its native replaceWidget(index).
         old_cheat = self._cheat
+        # Stop the old poller thread *before* swapping it out: deleteLater() /
+        # setParent(None) do not fire closeEvent, so the old QThread would
+        # otherwise keep reading from the previous process's now-closed handle
+        # until GC. shutdown() is idempotent and joins the worker.
+        try:
+            old_cheat.shutdown()
+        except Exception:
+            pass
         old_index = self._right_splitter.indexOf(old_cheat)
         self._cheat = CheatTable(self._process)
         self._cheat.pointer_scan_for_address.connect(self._open_pointer_scan_dialog)
@@ -819,12 +827,45 @@ class MainWindow(QMainWindow):
         self._status.showMessage(f"Now targeting PID {self._process.pid}.")
 
     def closeEvent(self, event: QCloseEvent) -> None:
-        if self._worker is not None:
-            self._worker.cancel()
-            self._worker.wait(_WORKER_SHUTDOWN_WAIT_MS)
+        # The cheat poller is a child widget but its closeEvent is *not*
+        # guaranteed to fire on a top-level window close — only on an explicit
+        # close of the child. Drive it directly so the QThread is stopped
+        # before the process handle goes away in `application.main`'s finally.
+        try:
+            self._cheat.shutdown()
+        except Exception:
+            pass
+
+        self._shutdown_worker()
         self._heartbeat.stop()
         self.closing.emit()
         super().closeEvent(event)
+
+    def _shutdown_worker(self) -> None:
+        """
+        Stop the active scan worker safely.
+
+        Disconnect every signal **before** waiting — if the wait times out
+        (long scan that ignores cancel), a late ``chunk_ready`` / ``finished``
+        emit would otherwise land on a half-destroyed UI. Then wait the
+        capped time and forcibly forget the worker either way.
+        """
+        worker = self._worker
+        if worker is None:
+            return
+        worker.cancel()
+        try:
+            worker.chunk_ready.disconnect()
+            worker.progress.disconnect()
+            worker.status.disconnect()
+            worker.error.disconnect()
+            worker.finished_ok.disconnect()
+            worker.finished.disconnect()
+        except (RuntimeError, TypeError):
+            # Already disconnected / no slots — fine, we just want them gone.
+            pass
+        worker.wait(_WORKER_SHUTDOWN_WAIT_MS)
+        self._worker = None
 
 
 def _safe_for_json(value) -> object:

--- a/PyMemoryEditor/linux/functions.py
+++ b/PyMemoryEditor/linux/functions.py
@@ -14,8 +14,13 @@ from ctypes import addressof, sizeof
 from typing import Dict, Generator, Optional, Sequence, Tuple, Type, TypeVar, Union
 
 from ..enums import ScanTypesEnum
+from ..process.errors import ProcessIDNotExistsError
 from ..process.module_info import ModuleInfo
-from ..process.region import enrich_region
+from ..process.region import (
+    default_address_filter,
+    default_scan_filter,
+    enrich_region,
+)
 from ..process.scanning import (
     iter_pattern_results,
     iter_search_results,
@@ -122,13 +127,64 @@ def _process_vm_writev(
     return result
 
 
+def _make_read_chunk(pid: int):
+    """
+    Build a `read_chunk(address, size)` closure bound to ``pid``.
+
+    Each backend used to define this closure inline three times
+    (``search_addresses_by_value``, ``search_addresses_by_pattern``,
+    ``search_values_by_addresses``) — drift between them was a recurring source
+    of subtle bugs. Owning it once per backend keeps the trio in lockstep.
+    """
+    def read_chunk(address: int, size: int):
+        buffer = (ctypes.c_byte * size)()
+        _process_vm_readv(pid, addressof(buffer), address, sizeof(buffer))
+        return buffer
+
+    return read_chunk
+
+
+def _is_transient(exc: BaseException) -> bool:
+    """
+    Classify ``exc`` as a transient page-vanished failure that scan loops
+    should swallow vs a real configuration / permission error that must
+    propagate. Shared by every scanning entry point.
+    """
+    # A short read mid-scan is equivalent to a page disappearing — the scan
+    # should skip the chunk and keep going. Real permission/configuration
+    # errors (EACCES, EPERM, ESRCH, EINVAL) propagate.
+    if isinstance(exc, _LinuxPartialIOError):
+        return True
+    return isinstance(exc, OSError) and exc.errno in _PAGE_GONE_ERRNOS
+
+
 def get_memory_regions(pid: int) -> Generator[dict, None, None]:
     """
     Generates dictionaries with the address and size of a region used by the process.
+
+    Translates the typical I/O failures of ``/proc/<pid>/maps`` into the
+    library's own exception hierarchy so callers don't have to special-case
+    raw ``FileNotFoundError`` / ``PermissionError`` from the kernel pseudo-fs.
     """
     mapping_filename = "/proc/{}/maps".format(pid)
 
-    with open(mapping_filename, "r") as mapping_file:
+    try:
+        mapping_file = open(mapping_filename, "r")
+    except FileNotFoundError:
+        # Target died between OpenProcess()'s pid_exists() check and now. The
+        # caller already accepts ProcessIDNotExistsError from the open path,
+        # so funnel into it instead of leaking a kernel pseudo-fs error.
+        raise ProcessIDNotExistsError(pid)
+    except PermissionError as exc:
+        # ptrace_scope (or being a non-root user inspecting a different uid)
+        # is the typical reason — re-raise with a hint pointing at the fix.
+        raise PermissionError(
+            "Cannot read %s: %s. On Linux this usually means ptrace_scope "
+            "is restricting access; try `sudo sysctl kernel.yama.ptrace_scope=0` "
+            "or run as root." % (mapping_filename, exc)
+        )
+
+    with mapping_file:
         for line in mapping_file:
             region_information = line.split()
 
@@ -262,34 +318,12 @@ def search_addresses_by_value(
         memory_regions if memory_regions is not None else get_memory_regions(pid)
     )
 
-    def is_scannable(region) -> bool:
-        privileges = region["struct"].Privileges
-        if b"r" not in privileges:
-            return False
-        if writeable_only and b"w" not in privileges:
-            return False
-        # Skip shared mappings — they typically hold libc and other code that
-        # the caller is not interested in, and scanning them adds noise and
-        # CPU cost. Mirrors the Win32 backend filtering on MEM_PRIVATE.
-        if b"s" in privileges:
-            return False
-        return True
-
-    filtered_regions = [region for region in source_regions if is_scannable(region)]
+    filtered_regions = [
+        region
+        for region in source_regions
+        if default_scan_filter(region, writeable_only=writeable_only)
+    ]
     filtered_regions.sort(key=lambda region: region["address"])
-
-    def read_chunk(address: int, size: int):
-        buffer = (ctypes.c_byte * size)()
-        _process_vm_readv(pid, addressof(buffer), address, sizeof(buffer))
-        return buffer
-
-    def is_transient(exc: BaseException) -> bool:
-        # A short read mid-scan is equivalent to a page disappearing — the
-        # scan should skip the chunk and keep going. Real permission /
-        # configuration errors (EACCES, EPERM, ESRCH, EINVAL) propagate.
-        if isinstance(exc, _LinuxPartialIOError):
-            return True
-        return isinstance(exc, OSError) and exc.errno in _PAGE_GONE_ERRNOS
 
     yield from iter_search_results(
         filtered_regions,
@@ -297,9 +331,9 @@ def search_addresses_by_value(
         bufflength,
         target_value_bytes,
         scan_type,
-        read_chunk,
+        _make_read_chunk(pid),
         progress_information=progress_information,
-        transient_error_check=is_transient,
+        transient_error_check=_is_transient,
     )
 
 
@@ -321,36 +355,18 @@ def search_addresses_by_pattern(
         memory_regions if memory_regions is not None else get_memory_regions(pid)
     )
 
-    def is_scannable(region) -> bool:
-        privileges = region["struct"].Privileges
-        if b"r" not in privileges:
-            return False
-        # Mirror search_addresses_by_value: skip shared mappings (libc text
-        # etc.) — they bloat scans with noise.
-        if b"s" in privileges:
-            return False
-        return True
-
-    filtered_regions = [region for region in source_regions if is_scannable(region)]
+    filtered_regions = [
+        region for region in source_regions if default_scan_filter(region)
+    ]
     filtered_regions.sort(key=lambda region: region["address"])
-
-    def read_chunk(address: int, size: int):
-        buffer = (ctypes.c_byte * size)()
-        _process_vm_readv(pid, addressof(buffer), address, sizeof(buffer))
-        return buffer
-
-    def is_transient(exc: BaseException) -> bool:
-        if isinstance(exc, _LinuxPartialIOError):
-            return True
-        return isinstance(exc, OSError) and exc.errno in _PAGE_GONE_ERRNOS
 
     yield from iter_pattern_results(
         filtered_regions,
         compiled,
         length,
-        read_chunk,
+        _make_read_chunk(pid),
         progress_information=progress_information,
-        transient_error_check=is_transient,
+        transient_error_check=_is_transient,
     )
 
 
@@ -380,32 +396,19 @@ def search_values_by_addresses(
     # the caller pre-filtered to zero regions.
     if memory_regions is None:
         memory_regions = [
-            region for region in get_memory_regions(pid) if region["is_readable"]
+            region for region in get_memory_regions(pid) if default_address_filter(region)
         ]
     else:
         memory_regions = list(memory_regions)
-
-    def read_chunk(address: int, size: int):
-        buffer = (ctypes.c_byte * size)()
-        _process_vm_readv(pid, addressof(buffer), address, sizeof(buffer))
-        return buffer
-
-    def is_transient(exc: BaseException) -> bool:
-        # A short read mid-scan is equivalent to a page disappearing — the
-        # scan should skip the chunk and keep going. Real permission /
-        # configuration errors (EACCES, EPERM, ESRCH, EINVAL) propagate.
-        if isinstance(exc, _LinuxPartialIOError):
-            return True
-        return isinstance(exc, OSError) and exc.errno in _PAGE_GONE_ERRNOS
 
     yield from iter_values_for_addresses(
         addresses,
         memory_regions,
         pytype,
         bufflength,
-        read_chunk,
+        _make_read_chunk(pid),
         raise_error=raise_error,
-        transient_error_check=is_transient,
+        transient_error_check=_is_transient,
     )
 
 

--- a/PyMemoryEditor/macos/functions.py
+++ b/PyMemoryEditor/macos/functions.py
@@ -13,7 +13,11 @@ from typing import Dict, Generator, List, Optional, Sequence, Tuple, Type, TypeV
 
 from ..enums import ScanTypesEnum
 from ..process.module_info import ModuleInfo
-from ..process.region import enrich_region
+from ..process.region import (
+    default_address_filter,
+    default_scan_filter,
+    enrich_region,
+)
 from ..process.scanning import (
     iter_pattern_results,
     iter_search_results,
@@ -62,6 +66,20 @@ _WRITE_RETRY_CODES = (KERN_PROTECTION_FAILURE, KERN_INVALID_ADDRESS)
 _logger = logging.getLogger("PyMemoryEditor")
 
 
+# When mach_vm_region returns a transient non-success code mid-enumeration we
+# bump the cursor by one page and keep going instead of silently truncating
+# the region list. 4 KiB is conservative: on Apple Silicon (16 KiB pages) we
+# simply make 4 small hops past a problem page, which is cheap. Sized small
+# enough that we do not accidentally skip a real adjacent region.
+_REGION_SKIP_BUMP = 0x1000
+
+# mach_vm_write's data_count parameter is `mach_msg_type_number_t` — a 32-bit
+# unsigned int per the Mach interface. A write larger than UINT32_MAX would
+# silently truncate at the kernel boundary. Guard it explicitly so the user
+# sees a real error instead of a partial write.
+_MACH_WRITE_MAX_SIZE = 0xFFFFFFFF
+
+
 T = TypeVar("T")
 
 
@@ -103,7 +121,13 @@ def release_task(task: int) -> None:
 def get_memory_regions(task: int) -> Generator[dict, None, None]:
     """
     Yield {address, size, struct} dicts describing each memory region of the task.
-    Stops when mach_vm_region returns a non-success code (typical end of address space).
+
+    ``mach_vm_region`` returning :data:`KERN_INVALID_ADDRESS` is the documented
+    way the kernel says "no more regions past this address" — the natural end
+    of the enumeration. Any *other* non-success code (``KERN_FAILURE``,
+    ``KERN_NO_ACCESS`` on a guard page, etc.) used to terminate enumeration
+    too, silently truncating the region list. Now those are logged and the
+    cursor is bumped one page so the walk keeps going.
     """
     address = mach_vm_address_t(0)
 
@@ -124,7 +148,15 @@ def get_memory_regions(task: int) -> Generator[dict, None, None]:
         )
 
         if kr != KERN_SUCCESS:
-            break
+            if kr == KERN_INVALID_ADDRESS:
+                return  # end of address space — the normal terminator
+            _logger.debug(
+                "get_memory_regions: mach_vm_region skipped 0x%X (kr=%d, %s); "
+                "advancing one page",
+                address.value, kr, mach_error_message(kr),
+            )
+            address.value += _REGION_SKIP_BUMP
+            continue
 
         # mach_vm_region returns a port name for the backing object; release it.
         if object_name.value:
@@ -148,7 +180,7 @@ def get_memory_regions(task: int) -> Generator[dict, None, None]:
         )
 
         if size.value == 0:
-            break
+            return
         address.value += size.value
 
 
@@ -225,7 +257,19 @@ def _mach_write(task: int, address: int, local_buffer_address: int, size: int) -
     so the change is private to the target task), performs the write, and
     restores the original protection. This mirrors the practical behavior of
     WriteProcessMemory on Windows.
+
+    ``mach_vm_write``'s ``data_count`` parameter is a 32-bit
+    ``mach_msg_type_number_t`` per the Mach interface; reject ``size`` values
+    that would silently truncate at the kernel boundary instead of letting
+    them slip through.
     """
+    if size > _MACH_WRITE_MAX_SIZE:
+        raise OverflowError(
+            "mach_vm_write size %d exceeds UINT32_MAX — the Mach interface "
+            "would silently truncate. Split the write into smaller chunks."
+            % size
+        )
+
     kr = libsystem.mach_vm_write(task, address, local_buffer_address, size)
     if kr == KERN_SUCCESS:
         return
@@ -279,6 +323,26 @@ def _mach_write(task: int, address: int, local_buffer_address: int, size: int) -
             )
             _logger.warning(message)
             warnings.warn(message, ResourceWarning, stacklevel=2)
+
+
+def _make_read_chunk(task: int):
+    """
+    Build a ``read_chunk(address, size)`` closure bound to ``task``.
+
+    Hoisted here so every ``search_*`` entry point uses one canonical
+    definition instead of re-declaring the closure inline three times.
+    """
+    def read_chunk(address: int, size: int):
+        buffer = (ctypes.c_byte * size)()
+        _mach_read(task, address, ctypes.addressof(buffer), size)
+        return buffer
+
+    return read_chunk
+
+
+def _is_transient(exc: BaseException) -> bool:
+    """Classify ``exc`` as a transient page-vanished failure for scan loops."""
+    return isinstance(exc, MachReadError) and exc.kr in _PAGE_GONE_KRS
 
 
 def _query_region(task: int, address: int):
@@ -442,24 +506,12 @@ def search_addresses_by_value(
         memory_regions if memory_regions is not None else get_memory_regions(task)
     )
 
-    def is_scannable(region) -> bool:
-        protection = region["struct"].Protection
-        if protection & VM_PROT_READ == 0:
-            return False
-        if writeable_only and protection & VM_PROT_WRITE == 0:
-            return False
-        return True
-
-    filtered_regions = [region for region in source_regions if is_scannable(region)]
+    filtered_regions = [
+        region
+        for region in source_regions
+        if default_scan_filter(region, writeable_only=writeable_only)
+    ]
     filtered_regions.sort(key=lambda region: region["address"])
-
-    def read_chunk(address: int, size: int):
-        buffer = (ctypes.c_byte * size)()
-        _mach_read(task, address, ctypes.addressof(buffer), size)
-        return buffer
-
-    def is_transient(exc: BaseException) -> bool:
-        return isinstance(exc, MachReadError) and exc.kr in _PAGE_GONE_KRS
 
     yield from iter_search_results(
         filtered_regions,
@@ -467,9 +519,9 @@ def search_addresses_by_value(
         bufflength,
         target_value_bytes,
         scan_type,
-        read_chunk,
+        _make_read_chunk(task),
         progress_information=progress_information,
-        transient_error_check=is_transient,
+        transient_error_check=_is_transient,
     )
 
 
@@ -774,27 +826,18 @@ def search_addresses_by_pattern(
         memory_regions if memory_regions is not None else get_memory_regions(task)
     )
 
-    def is_scannable(region) -> bool:
-        return (region["struct"].Protection & VM_PROT_READ) != 0
-
-    filtered_regions = [region for region in source_regions if is_scannable(region)]
+    filtered_regions = [
+        region for region in source_regions if default_scan_filter(region)
+    ]
     filtered_regions.sort(key=lambda region: region["address"])
-
-    def read_chunk(address: int, size: int):
-        buffer = (ctypes.c_byte * size)()
-        _mach_read(task, address, ctypes.addressof(buffer), size)
-        return buffer
-
-    def is_transient(exc: BaseException) -> bool:
-        return isinstance(exc, MachReadError) and exc.kr in _PAGE_GONE_KRS
 
     yield from iter_pattern_results(
         filtered_regions,
         compiled,
         length,
-        read_chunk,
+        _make_read_chunk(task),
         progress_information=progress_information,
-        transient_error_check=is_transient,
+        transient_error_check=_is_transient,
     )
 
 
@@ -823,25 +866,17 @@ def search_values_by_addresses(
     # the caller pre-filtered to zero regions.
     if memory_regions is None:
         memory_regions = [
-            region for region in get_memory_regions(task) if region["is_readable"]
+            region for region in get_memory_regions(task) if default_address_filter(region)
         ]
     else:
         memory_regions = list(memory_regions)
-
-    def read_chunk(address: int, size: int):
-        buffer = (ctypes.c_byte * size)()
-        _mach_read(task, address, ctypes.addressof(buffer), size)
-        return buffer
-
-    def is_transient(exc: BaseException) -> bool:
-        return isinstance(exc, MachReadError) and exc.kr in _PAGE_GONE_KRS
 
     yield from iter_values_for_addresses(
         addresses,
         memory_regions,
         pytype,
         bufflength,
-        read_chunk,
+        _make_read_chunk(task),
         raise_error=raise_error,
-        transient_error_check=is_transient,
+        transient_error_check=_is_transient,
     )

--- a/PyMemoryEditor/process/region.py
+++ b/PyMemoryEditor/process/region.py
@@ -173,8 +173,49 @@ def enrich_region(region: dict) -> dict:
     return region
 
 
+def default_scan_filter(region: dict, *, writeable_only: bool = False) -> bool:
+    """
+    Single source of truth for "which regions does a *value* / *pattern* scan
+    walk by default".
+
+    Historically each backend rolled its own filter — Win32 excluded
+    ``MEM_MAPPED`` via ``Type``, Linux excluded shared via ``'s'`` in
+    privileges, and macOS excluded nothing — so the same call returned a
+    different set of matches per OS. The portable booleans on the region dict
+    (populated by :func:`enrich_region`) let one filter cover all three:
+
+    - must be readable (no syscall hops into unreadable pages),
+    - if ``writeable_only``, must also be writable,
+    - drop shared mappings (libc text, file-backed pages): they're full of
+      noise the caller virtually never wants in a value scan, and matching the
+      Linux/Win32 historical behavior is the practical default.
+    """
+    if not region.get("is_readable", False):
+        return False
+    if writeable_only and not region.get("is_writable", False):
+        return False
+    if region.get("is_shared", False):
+        return False
+    return True
+
+
+def default_address_filter(region: dict) -> bool:
+    """
+    Single source of truth for "which regions does an *address-list* read walk
+    by default" (``search_by_addresses`` without a snapshot).
+
+    Crucially this is *not* the same as :func:`default_scan_filter`: when the
+    caller hands the library a concrete address, the library has no business
+    second-guessing whether the region is "interesting". The only requirement
+    is that the region is readable — same on every OS.
+    """
+    return bool(region.get("is_readable", False))
+
+
 __all__ = (
     "REGION_KEYS",
+    "default_address_filter",
+    "default_scan_filter",
     "enrich_region",
     "is_region_executable",
     "is_region_readable",

--- a/PyMemoryEditor/win32/functions.py
+++ b/PyMemoryEditor/win32/functions.py
@@ -13,7 +13,11 @@ from typing import Dict, Generator, Optional, Sequence, Tuple, Type, TypeVar, Un
 
 from ..enums import ScanTypesEnum
 from ..process.module_info import ModuleInfo
-from ..process.region import enrich_region
+from ..process.region import (
+    default_address_filter,
+    default_scan_filter,
+    enrich_region,
+)
 from ..process.scanning import (
     iter_pattern_results,
     iter_search_results,
@@ -27,7 +31,7 @@ from ..util import (
 )
 from ..util.pattern import PatternLike, compile_pattern
 
-from .enums import MemoryAllocationStatesEnum, MemoryProtectionsEnum, MemoryTypesEnum
+from .enums import MemoryAllocationStatesEnum, MemoryProtectionsEnum
 from .types import (
     MEMORY_BASIC_INFORMATION,
     MEMORY_BASIC_INFORMATION_32,
@@ -233,15 +237,24 @@ def GetMemoryRegions(process_handle: int) -> Generator[dict, None, None]:
     Picks the right MEMORY_BASIC_INFORMATION layout (32-bit vs 64-bit) for the
     target process to handle the WOW64 case (64-bit Python attached to a 32-bit
     target). VirtualQueryEx is dispatched against `mbi_class` accordingly.
+
+    ``VirtualQueryEx`` returning 0 used to terminate enumeration unconditionally,
+    silently truncating the region list whenever the kernel hiccuped on a
+    single region (DLL unloaded mid-walk, transient permission edge). Now we
+    consult ``GetLastError``: only fall through for the natural end-of-space
+    case; for any other failure log it and bump the cursor by one page so the
+    walk keeps making progress.
     """
     mbi_class = mbi_class_for_handle(process_handle)
     mem_region_begin = system_information.lpMinimumApplicationAddress
     mem_region_end = system_information.lpMaximumApplicationAddress
+    page_size = system_information.dwPageSize or 0x1000
 
     current_address = mem_region_begin
 
     while current_address < mem_region_end:
         region = mbi_class()
+        ctypes.set_last_error(0)
         result = kernel32.VirtualQueryEx(
             process_handle,
             current_address,
@@ -250,14 +263,30 @@ def GetMemoryRegions(process_handle: int) -> Generator[dict, None, None]:
         )
 
         if result == 0:
-            break
+            err = ctypes.get_last_error()
+            # ERROR_INVALID_PARAMETER (87) is what VirtualQueryEx returns once
+            # we walk past lpMaximumApplicationAddress on some Windows builds —
+            # the natural end. Anything else is a transient skip, not a
+            # terminator: log and step one page forward.
+            if err in (0, 87):
+                return
+            _logger.debug(
+                "GetMemoryRegions: VirtualQueryEx skipped 0x%X (err=%d); "
+                "advancing one page",
+                current_address, err,
+            )
+            current_address += page_size
+            continue
 
         yield enrich_region(
             {"address": current_address, "size": region.RegionSize, "struct": region}
         )
 
         if region.RegionSize == 0:
-            break
+            # Defensive: would otherwise spin forever. Bump one page and keep
+            # going so a single weird region can't cap the enumeration either.
+            current_address += page_size
+            continue
         current_address += region.RegionSize
 
 
@@ -329,26 +358,6 @@ def ReadProcessMemory(
         return data.value
 
 
-def _is_region_scannable(region, writeable_only: bool) -> bool:
-    """Check whether a memory region should be scanned (private or image, committed, readable)."""
-    info = region["struct"]
-    if info.State != MemoryAllocationStatesEnum.MEM_COMMIT.value:
-        return False
-    if info.Type not in (
-        MemoryTypesEnum.MEM_PRIVATE.value,
-        MemoryTypesEnum.MEM_IMAGE.value,
-    ):
-        return False
-    if info.Protect & MemoryProtectionsEnum.PAGE_READABLE.value == 0:
-        return False
-    if (
-        writeable_only
-        and info.Protect & MemoryProtectionsEnum.PAGE_READWRITEABLE.value == 0
-    ):
-        return False
-    return True
-
-
 def _read_region(process_handle: int, address: int, size: int):
     """Read a memory region; returns the byte buffer or None on failure."""
     region_data = (ctypes.c_byte * size)()
@@ -396,7 +405,7 @@ def SearchAddressesByValue(
     filtered_regions = [
         region
         for region in source_regions
-        if _is_region_scannable(region, writeable_only)
+        if default_scan_filter(region, writeable_only=writeable_only)
     ]
     filtered_regions.sort(key=lambda region: region["address"])
 
@@ -437,9 +446,7 @@ def SearchAddressesByPattern(
         else GetMemoryRegions(process_handle)
     )
     filtered_regions = [
-        region
-        for region in source_regions
-        if _is_region_scannable(region, writeable_only=False)
+        region for region in source_regions if default_scan_filter(region)
     ]
     filtered_regions.sort(key=lambda region: region["address"])
 
@@ -490,10 +497,11 @@ def SearchValuesByAddresses(
         memory_regions = [
             region
             for region in GetMemoryRegions(process_handle)
-            # Accept both private and image (loaded DLLs) regions, matching
-            # SearchAddressesByValue. Previously this filter was stricter and
-            # caused addresses found via search_by_value to fail here.
-            if _is_region_scannable(region, writeable_only=False)
+            # An address-list read has the caller already deciding *where* —
+            # the library has no business filtering by region "interestingness"
+            # (which used to exclude MEM_MAPPED here and diverge from
+            # Linux/macOS). All three backends now agree: just readable.
+            if default_address_filter(region)
         ]
     else:
         memory_regions = list(memory_regions)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,5 +127,15 @@ skip_empty = true
 # ``test_*.py`` together on a single worker (module-scoped fixtures stay
 # valid), and ``-n auto`` picks one worker per available CPU. Override with
 # ``pytest -n 0`` for serial debugging.
+#
+# Fast vs slow split:
+#   pytest -m "not slow"        # ~30 s — unit/property/GUI tests only.
+#   pytest                      # ~20 min — everything, including the live
+#                               # self-process integration suite.
+# Mark a test (or set ``pytestmark = pytest.mark.slow`` at module scope) to
+# add it to the slow bucket — see tests/test_editor.py for the pattern.
 [tool.pytest.ini_options]
 addopts = "-n auto --dist=loadfile"
+markers = [
+    "slow: integration tests that read/scan the current process's whole address space (minutes, not seconds)",
+]

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -20,6 +20,10 @@ import pytest
 
 from PyMemoryEditor import OpenProcess, ScanTypesEnum
 
+# Live scans of the entire test-process address space — minutes, not seconds.
+# Run with ``pytest -m "not slow"`` to skip them during fast feedback loops.
+pytestmark = pytest.mark.slow
+
 
 # The default permission on Windows already includes read+write, but spell
 # the mask out here so the suite stays explicit about what it needs. Linux

--- a/tests/test_pattern_scan.py
+++ b/tests/test_pattern_scan.py
@@ -26,6 +26,11 @@ if sys.platform not in ("win32", "darwin") and not sys.platform.startswith("linu
 from PyMemoryEditor import OpenProcess  # noqa: E402
 
 
+# Live pattern scans of the entire test-process address space — slow.
+# Run with ``pytest -m "not slow"`` to skip them during fast feedback loops.
+pytestmark = pytest.mark.slow
+
+
 # A reasonably distinctive marker — eight bytes give us enough entropy that
 # random other matches in the test process's address space are unlikely.
 _MARKER = b"\x90\x90\xDE\xAD\xBE\xEF\xCA\xFE"

--- a/tests/test_pointer_scan.py
+++ b/tests/test_pointer_scan.py
@@ -200,6 +200,10 @@ def test_max_results_caps_output():
 # --------------------------------------------------------------------------- #
 # Integration against the running process
 # --------------------------------------------------------------------------- #
+#
+# These tests build a real pointer map over the whole test process — slow.
+# Each one carries ``@pytest.mark.slow`` so ``pytest -m "not slow"`` skips the
+# integration half while keeping the unit tests above in the fast subset.
 
 @pytest.fixture
 def process():
@@ -210,6 +214,7 @@ def process():
         handle.close()
 
 
+@pytest.mark.slow
 def test_scan_pointer_paths_rediscovers_planted_chain(process):
     """
     Plant ``base -> [+0] -> +offset`` on the heap, mark the base's address as a
@@ -255,11 +260,13 @@ def test_scan_pointer_paths_rediscovers_planted_chain(process):
     ), [str(p) for p in resolving]
 
 
+@pytest.mark.slow
 def test_scan_pointer_paths_rejects_bad_ptr_size(process):
     with pytest.raises(ValueError, match="ptr_size"):
         list(process.scan_pointer_paths(0x1000, ptr_size=5))
 
 
+@pytest.mark.slow
 def test_save_load_pointer_paths_round_trip(process, tmp_path):
     paths = [
         PointerPath(0x1000, (0x0, 0x158), module="m.dylib", module_offset=0x10),
@@ -271,6 +278,7 @@ def test_save_load_pointer_paths_round_trip(process, tmp_path):
     assert loaded == paths
 
 
+@pytest.mark.slow
 def test_rescan_pointer_paths_keeps_only_resolving(process, tmp_path):
     """
     Plant a chain, save a path to it plus a decoy, and confirm rescan keeps the
@@ -293,6 +301,7 @@ def test_rescan_pointer_paths_keeps_only_resolving(process, tmp_path):
     assert decoy not in survivors
 
 
+@pytest.mark.slow
 def test_rescan_pointer_paths_accepts_list(process):
     ptr_size = ctypes.sizeof(ctypes.c_void_p)
     obj = (ctypes.c_uint8 * 0x40)()
@@ -304,6 +313,7 @@ def test_rescan_pointer_paths_accepts_list(process):
     assert survivors == [good]
 
 
+@pytest.mark.slow
 def test_compare_pointer_scans_via_process(process, tmp_path):
     common = PointerPath(0x1, (0x8,), module="a.exe", module_offset=0x10)
     only1 = PointerPath(0x1, (0x4,), module="a.exe", module_offset=0x20)

--- a/tests/test_scan_properties.py
+++ b/tests/test_scan_properties.py
@@ -26,6 +26,12 @@ from PyMemoryEditor.enums import ScanTypesEnum  # noqa: E402
 from PyMemoryEditor.util.scan import scan_memory  # noqa: E402
 
 
+# Hypothesis property-based tests — each draws hundreds of cases, easily the
+# slowest non-integration file in the suite. Marked slow so ``pytest -m "not
+# slow"`` keeps the fast subset really fast.
+pytestmark = pytest.mark.slow
+
+
 # Pre-compute valid value counts per (size, pytype) so hypothesis doesn't burn
 # cycles on inputs the slow path silently rejects.
 _INT_SIZES = (1, 2, 4, 8)


### PR DESCRIPTION
Six related fixes that landed together because they touch the same seams in the backends and the app:

1. Unified region filter (process/region.py) Adds default_scan_filter / default_address_filter and points all three backends at them. search_by_value / search_by_pattern now yield the same matches on every OS (macOS used to keep shared regions that Linux/Win32 dropped); search_by_addresses is uniformly "readable only" — the Win32 path no longer excludes MEM_MAPPED when the caller already supplied the address.

2. Silent region-enumeration truncation
   - win32/GetMemoryRegions: discriminate GetLastError; transient failures bump one page instead of breaking the whole walk.
   - macos/get_memory_regions: only KERN_INVALID_ADDRESS terminates; other kr codes log and advance by a page.
   - linux/get_memory_regions: open(/proc/<pid>/maps) failures map to ProcessIDNotExistsError / PermissionError with a ptrace_scope hint instead of leaking raw kernel pseudo-fs errors.

3. Fast/slow test split (pyproject.toml + tests/) Register the `slow` marker and tag the live full-process scans (test_editor, test_pattern_scan, test_scan_properties, and the integration half of test_pointer_scan). `pytest -m "not slow"` now runs in ~2 s instead of ~18 min for the fast feedback loop; default `pytest` still runs everything.

4. App worker lifecycle on teardown (app/main_window.py, app/cheat_table.py)
   - MainWindow.closeEvent now disconnects worker signals before wait()-ing, so a long scan that exceeds the 2 s cap can no longer deliver chunk_ready/finished into a destroyed model.
   - CheatTable.shutdown() is a public, idempotent stop+join that closeEvent and _change_process drive explicitly — deleteLater() does not fire closeEvent, so the old poller used to keep reading from the previous (now-closed) handle until GC.

5. Backend de-duplication (linux/macos/functions.py) The read_chunk and is_transient closures used to be copy-pasted three times per backend; hoisted to module-level _make_read_chunk and _is_transient helpers so the trio stays in lockstep.

6. mach_vm_write 32-bit data_count (macos/functions.py) mach_vm_write's data_count is mach_msg_type_number_t (32-bit) per the Mach interface; _mach_write now raises OverflowError when the requested size exceeds UINT32_MAX instead of silently truncating at the kernel boundary.

Validation:
  flake8 PyMemoryEditor tests   -> clean
  mypy PyMemoryEditor           -> Success: no issues found in 36 source files
  pytest -m "not slow"          -> 176 passed, 13 skipped in 2.00s
  pytest                        -> 206 passed, 13 skipped in 17m30s (parity with baseline)

**Why is this PR necessary, what does it do?**

<!-- 
IMPORTANT! Explain the **motivation** for making this change: what existing
problem the pull request solves or what new features it implements.
-->

**Checklist (complete all items)**:

- [x] Added tests as necessary.
- [x] There is no breaking change for existing features.

**References:**

<!-- (Nice to have) 
Link tasks, issues, PRs that are related to this pull request, etc. 
-->

No references to be shared. 

**Notes:**

<!-- (Optional) 
Explain some changes that can be useful when reviewing this pull request. 
-->

No notes to be shared. 