### PR TITLE
feat: implement MemoryRegion dataclass and full Sphinx documentation site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,5 +76,8 @@ Desktop.ini
 *.log
 *.tmp
 
+# Sphinx / docs build output
+docs/_build/
+
 # Project-local
 .claude/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,24 @@
+# Read the Docs configuration file for Sphinx + MyST.
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: false
+
+formats:
+  - htmlzip
+  - pdf
+  - epub
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ DIST_DIR = dist
 EGG_INFO = $(PACKAGE_NAME).egg-info
 VENV_DIR = venv
 TEST_DIR = tests
+DOCS_DIR = docs
+DOCS_BUILD_DIR = $(DOCS_DIR)/_build/html
 
 # Colors for output
 GREEN = \033[0;32m
@@ -44,7 +46,10 @@ help:
 	@echo "  $(YELLOW)check-deps$(NC)       - Check for outdated dependencies"
 	@echo "  $(YELLOW)update-deps$(NC)      - Update dependencies"
 	@echo "  $(YELLOW)security$(NC)         - Run security audit"
-	@echo "  $(YELLOW)docs$(NC)             - Generate documentation"
+	@echo "  $(YELLOW)install-docs$(NC)     - Install dependencies to build the documentation"
+	@echo "  $(YELLOW)docs$(NC)             - Build the HTML documentation (output: $(DOCS_BUILD_DIR))"
+	@echo "  $(YELLOW)docs-serve$(NC)       - Live-reload docs server at http://127.0.0.1:8000"
+	@echo "  $(YELLOW)docs-clean$(NC)       - Remove the docs build directory"
 	@echo "  $(YELLOW)venv$(NC)             - Create virtual environment"
 	@echo "  $(YELLOW)venv-activate$(NC)    - Show command to activate venv"
 	@echo "  $(YELLOW)all$(NC)              - Run full pipeline (install, lint, test, build)"
@@ -223,16 +228,38 @@ security:
 	pip-audit
 	@echo "$(GREEN)Security audit completed!$(NC)"
 
-# Generate documentation
+# Install the dependencies needed to build the documentation (Sphinx + MyST +
+# Furo + extensions, listed in docs/requirements.txt). Also installs the
+# package itself in editable mode so autodoc can import it.
+.PHONY: install-docs
+install-docs:
+	@echo "$(GREEN)Installing documentation dependencies...$(NC)"
+	$(PIP) install -r $(DOCS_DIR)/requirements.txt
+	$(PIP) install -e .
+	@echo "$(GREEN)Docs dependencies installed!$(NC)"
+
+# Build the HTML documentation. Output lands in $(DOCS_BUILD_DIR).
 .PHONY: docs
 docs:
-	@echo "$(GREEN)Generating documentation...$(NC)"
-	@if [ -d "docs" ]; then \
-		cd docs && make html; \
-		echo "$(GREEN)Documentation generated in docs/_build/html/$(NC)"; \
-	else \
-		echo "$(YELLOW)No docs directory found. Skipping documentation generation.$(NC)"; \
-	fi
+	@echo "$(GREEN)Building HTML documentation...$(NC)"
+	$(PYTHON) -m sphinx -b html $(DOCS_DIR) $(DOCS_BUILD_DIR)
+	@echo "$(GREEN)Documentation generated at $(DOCS_BUILD_DIR)/index.html$(NC)"
+
+# Live-reload docs server — rebuilds on every save and reloads the browser.
+# Requires `sphinx-autobuild` (installed automatically via install-docs is
+# optional; we install it on demand here for convenience).
+.PHONY: docs-serve
+docs-serve:
+	@echo "$(GREEN)Starting live-reload docs server at http://127.0.0.1:8000$(NC)"
+	@$(PYTHON) -c "import sphinx_autobuild" 2>/dev/null || $(PIP) install sphinx-autobuild
+	$(PYTHON) -m sphinx_autobuild $(DOCS_DIR) $(DOCS_BUILD_DIR) --open-browser
+
+# Wipe the built docs.
+.PHONY: docs-clean
+docs-clean:
+	@echo "$(GREEN)Cleaning docs build directory...$(NC)"
+	rm -rf $(DOCS_DIR)/_build
+	@echo "$(GREEN)Docs build directory removed.$(NC)"
 
 # Full development pipeline
 .PHONY: all

--- a/PyMemoryEditor/__init__.py
+++ b/PyMemoryEditor/__init__.py
@@ -25,6 +25,7 @@ from .process.errors import (
 )
 from .process.module_info import ModuleInfo
 from .process.pointer_scan import PointerPath
+from .process.region import MemoryRegion, MemoryRegionSnapshot
 from .process.remote_pointer import RemotePointer
 from .process.thread_info import ThreadInfo
 
@@ -84,6 +85,8 @@ __all__ = (
     "AbstractProcess",
     "AmbiguousProcessNameError",
     "ClosedProcess",
+    "MemoryRegion",
+    "MemoryRegionSnapshot",
     "ModuleInfo",
     "OpenProcess",
     "PointerPath",

--- a/PyMemoryEditor/app/memory_map_dialog.py
+++ b/PyMemoryEditor/app/memory_map_dialog.py
@@ -16,7 +16,7 @@ dialog also publishes its last snapshot so the main window can reuse it as the
 ``memory_regions`` kwarg to subsequent scans.
 """
 import sys
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from PySide6.QtCore import Qt, QThread, QTimer, Signal
 from PySide6.QtGui import QFont, QGuiApplication, QStandardItem, QStandardItemModel
@@ -35,7 +35,7 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
 )
 
-from PyMemoryEditor import AbstractProcess
+from PyMemoryEditor import AbstractProcess, MemoryRegion, MemoryRegionSnapshot
 
 from ._widgets import NumericItem
 
@@ -43,7 +43,7 @@ from ._widgets import NumericItem
 class _SnapshotWorker(QThread):
     """Background thread that runs ``snapshot_memory_regions()`` off the UI."""
 
-    snapshot_ready = Signal(object)  # List[Dict]
+    snapshot_ready = Signal(object)  # List[MemoryRegion]
     snapshot_failed = Signal(str)
 
     def __init__(self, process: AbstractProcess, parent=None):
@@ -95,12 +95,12 @@ def _parse_amount(text: str) -> Optional[float]:
     return value if value > 0 else None
 
 
-def _decode_protection(region: Dict) -> str:
+def _decode_protection(region) -> str:
     """
     Translate the platform-specific protection field into a short ``R W X`` /
     ``private``-style string. Falls back to the raw int if we can't recognise it.
     """
-    struct = region.get("struct")
+    struct = region.struct
 
     if sys.platform == "win32":
         # Windows: the low byte of Protect is one of the mutually-exclusive
@@ -167,15 +167,13 @@ def _decode_protection(region: Dict) -> str:
         return "-"
 
 
-def _region_path(region: Dict) -> str:
+def _region_path(region) -> str:
     """On Linux, surface the backing file path (so the user sees [stack], [heap] etc)."""
-    return region.get("path") or ""
+    return region.path or ""
 
 
-def _region_shared(region: Dict) -> str:
-    if "is_shared" not in region:
-        return "—"
-    return "Shared" if region["is_shared"] else "Private"
+def _region_shared(region) -> str:
+    return "Shared" if region.is_shared else "Private"
 
 
 class MemoryMapDialog(QDialog):
@@ -187,7 +185,7 @@ class MemoryMapDialog(QDialog):
     def __init__(self, process: AbstractProcess, parent=None):
         super().__init__(parent)
         self._process = process
-        self._snapshot: List[Dict] = []
+        self._snapshot: List[MemoryRegion] = []
         self._worker: Optional[_SnapshotWorker] = None
 
         # allocate/free are a Windows/macOS capability (Linux raises
@@ -360,9 +358,13 @@ class MemoryMapDialog(QDialog):
             "QPushButton#secondary { padding: 5px 12px; min-height: 0px; }"
         )
 
-    def snapshot(self) -> List[Dict]:
-        """Return the cached region snapshot so the scanner can reuse it."""
-        return list(self._snapshot)
+    def snapshot(self) -> MemoryRegionSnapshot:
+        """Return the cached region snapshot so the scanner can reuse it.
+
+        Wrapped in :class:`MemoryRegionSnapshot` so the scan helpers detect the
+        pre-sorted contract and skip their per-call ``sorted(...)`` step.
+        """
+        return MemoryRegionSnapshot(self._snapshot)
 
     def refresh(self) -> None:
         # Skip if a snapshot is already in flight — the 1000ms auto-refresh timer
@@ -385,7 +387,10 @@ class MemoryMapDialog(QDialog):
         worker.start()
 
     def _on_snapshot_ready(self, snapshot) -> None:
-        self._snapshot = list(snapshot)
+        # Preserve the MemoryRegionSnapshot tag — scans that reuse this cache
+        # via the ``memory_regions=`` kwarg rely on the isinstance check to
+        # skip the per-call ``sorted(...)`` step.
+        self._snapshot = MemoryRegionSnapshot(snapshot)
         self._populate()
 
     def _populate(self) -> None:
@@ -404,7 +409,7 @@ class MemoryMapDialog(QDialog):
         scroll_value = self._table.verticalScrollBar().value()
 
         total = len(self._snapshot)
-        total_bytes = sum(int(region["size"]) for region in self._snapshot)
+        total_bytes = sum(int(region.size) for region in self._snapshot)
 
         # Disable sorting while rebuilding so the model isn't re-sorted on every
         # appendRow (and rows don't shuffle mid-build).
@@ -413,8 +418,8 @@ class MemoryMapDialog(QDialog):
 
         shown = 0
         for region in self._snapshot:
-            addr = int(region["address"])
-            size = int(region["size"])
+            addr = int(region.address)
+            size = int(region.size)
             path = _region_path(region) or ""
 
             if needle and needle not in path.lower() and needle not in f"0x{addr:x}":
@@ -499,14 +504,21 @@ class MemoryMapDialog(QDialog):
             self._worker.wait(1000)
         super().closeEvent(event)
 
-    def _selected_region(self) -> Optional[Dict]:
+    def _selected_region(self) -> Optional[MemoryRegion]:
         rows = self._table.selectionModel().selectedRows()
         if not rows:
             return None
         row = rows[0].row()
-        addr = self._model.item(row, 0).data(Qt.UserRole)
-        size = self._model.item(row, 1).data(Qt.UserRole)
-        return {"address": int(addr), "size": int(size)}
+        addr = int(self._model.item(row, 0).data(Qt.UserRole))
+        # Look up the real MemoryRegion from the snapshot so callers get the
+        # full set of fields (is_writable, struct, path, …). Falls back to a
+        # minimal stub if the row's address is no longer in the snapshot
+        # (rare; can happen if the map refreshed mid-selection).
+        for region in self._snapshot:
+            if region.address == addr:
+                return region
+        size = int(self._model.item(row, 1).data(Qt.UserRole))
+        return MemoryRegion(address=addr, size=size)
 
     def _show_context_menu(self, pos) -> None:
         """Right-click menu on a region row: copy its address or backing path."""
@@ -546,8 +558,8 @@ class MemoryMapDialog(QDialog):
             QMessageBox.information(self, "Memory Map", "Select a region first.")
             return
         # Cap the initial view to keep the hex widget responsive on huge regions.
-        size = min(region["size"], 4096)
-        self.open_hex_viewer.emit(region["address"], size)
+        size = min(region.size, 4096)
+        self.open_hex_viewer.emit(region.address, size)
 
     def _on_allocate(self) -> None:
         amount = _parse_amount(self._size_edit.text())
@@ -593,7 +605,7 @@ class MemoryMapDialog(QDialog):
             QMessageBox.information(self, "Memory Map", "Select a region to free first.")
             return
 
-        address = region["address"]
+        address = region.address
         reply = QMessageBox.warning(
             self,
             "Free memory",

--- a/PyMemoryEditor/app/scan_worker.py
+++ b/PyMemoryEditor/app/scan_worker.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from PySide6.QtCore import QThread, Signal
 
-from PyMemoryEditor import AbstractProcess, ScanTypesEnum
+from PyMemoryEditor import AbstractProcess, MemoryRegion, ScanTypesEnum
 
 from .scan_types import NextScanType, ScanType
 from .value_types import ValueTypeSpec
@@ -70,7 +70,7 @@ class ScanRequest:
     writeable_only: bool = False
     # Optional cached snapshot of memory regions, reused across scans to skip
     # the region enumeration step. Pass None to let the backend enumerate.
-    memory_regions: Optional[Sequence[Dict]] = None
+    memory_regions: Optional[Sequence[MemoryRegion]] = None
 
 
 class _BaseWorker(QThread):

--- a/PyMemoryEditor/linux/functions.py
+++ b/PyMemoryEditor/linux/functions.py
@@ -17,9 +17,10 @@ from ..enums import ScanTypesEnum
 from ..process.errors import ProcessIDNotExistsError
 from ..process.module_info import ModuleInfo
 from ..process.region import (
+    MemoryRegion,
     default_address_filter,
     default_scan_filter,
-    enrich_region,
+    make_region,
 )
 from ..process.scanning import (
     iter_pattern_results,
@@ -158,9 +159,9 @@ def _is_transient(exc: BaseException) -> bool:
     return isinstance(exc, OSError) and exc.errno in _PAGE_GONE_ERRNOS
 
 
-def get_memory_regions(pid: int) -> Generator[dict, None, None]:
+def get_memory_regions(pid: int) -> Generator["MemoryRegion", None, None]:
     """
-    Generates dictionaries with the address and size of a region used by the process.
+    Yield a :class:`MemoryRegion` for each entry in ``/proc/<pid>/maps``.
 
     Translates the typical I/O failures of ``/proc/<pid>/maps`` into the
     library's own exception hierarchy so callers don't have to special-case
@@ -218,12 +219,10 @@ def get_memory_regions(pid: int) -> Generator[dict, None, None]:
                 inode,
                 path_bytes,
             )
-            yield enrich_region(
-                {
-                    "address": start_address,
-                    "size": region.RegionSize,
-                    "struct": region,
-                }
+            yield make_region(
+                address=start_address,
+                size=region.RegionSize,
+                struct=region,
             )
 
 
@@ -248,12 +247,12 @@ def get_modules(pid: int) -> Generator[ModuleInfo, None, None]:
     first_seen = []
 
     for region in get_memory_regions(pid):
-        path = region["path"]
+        path = region.path
         if not path.startswith("/"):
             continue
 
-        start = region["address"]
-        end = start + region["size"]
+        start = region.address
+        end = start + region.size
 
         entry = bounds.get(path)
         if entry is None:
@@ -302,7 +301,7 @@ def search_addresses_by_value(
     progress_information: bool = False,
     writeable_only: bool = False,
     *,
-    memory_regions: Optional[Sequence[Dict]] = None,
+    memory_regions: Optional[Sequence[MemoryRegion]] = None,
 ) -> Generator[Union[int, Tuple[int, dict]], None, None]:
     """
     Search the whole memory space, accessible to the process,
@@ -323,7 +322,7 @@ def search_addresses_by_value(
         for region in source_regions
         if default_scan_filter(region, writeable_only=writeable_only)
     ]
-    filtered_regions.sort(key=lambda region: region["address"])
+    filtered_regions.sort(key=lambda region: region.address)
 
     yield from iter_search_results(
         filtered_regions,
@@ -343,7 +342,7 @@ def search_addresses_by_pattern(
     *,
     byte_length: int = 0,
     progress_information: bool = False,
-    memory_regions: Optional[Sequence[Dict]] = None,
+    memory_regions: Optional[Sequence[MemoryRegion]] = None,
 ) -> Generator[Union[int, Tuple[int, dict]], None, None]:
     """
     AOB scan against every readable, non-shared region of the target. See
@@ -358,7 +357,7 @@ def search_addresses_by_pattern(
     filtered_regions = [
         region for region in source_regions if default_scan_filter(region)
     ]
-    filtered_regions.sort(key=lambda region: region["address"])
+    filtered_regions.sort(key=lambda region: region.address)
 
     yield from iter_pattern_results(
         filtered_regions,
@@ -376,7 +375,7 @@ def search_values_by_addresses(
     bufflength: int,
     addresses: Sequence[int],
     *,
-    memory_regions: Optional[Sequence[Dict]] = None,
+    memory_regions: Optional[Sequence[MemoryRegion]] = None,
     raise_error: bool = False,
 ) -> Generator[Tuple[int, Optional[T]], None, None]:
     """

--- a/PyMemoryEditor/linux/process.py
+++ b/PyMemoryEditor/linux/process.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 
 import warnings
-from typing import Dict, Generator, Optional, Sequence, Tuple, Type, TypeVar, Union
+from typing import Generator, Optional, Sequence, Tuple, Type, TypeVar, Union
 
 from ..enums import ScanTypesEnum
 from ..process import AbstractProcess
 from ..process.errors import ClosedProcess
 from ..util import resolve_bufflength
 from ..process.module_info import ModuleInfo
+from ..process.region import MemoryRegion
 from ..process.thread_info import ThreadInfo
 from .functions import (
     get_memory_regions,
@@ -108,7 +109,7 @@ class LinuxProcess(AbstractProcess):
         addresses: Sequence[int],
         *,
         raise_error: bool = False,
-        memory_regions: Optional[Sequence[Dict]] = None,
+        memory_regions: Optional[Sequence[MemoryRegion]] = None,
     ) -> Generator[Tuple[int, Optional[T]], None, None]:
         self.__require_open()
         return search_values_by_addresses(
@@ -129,7 +130,7 @@ class LinuxProcess(AbstractProcess):
         *,
         progress_information: bool = False,
         writeable_only: bool = False,
-        memory_regions: Optional[Sequence[Dict]] = None,
+        memory_regions: Optional[Sequence[MemoryRegion]] = None,
     ) -> Generator[Union[int, Tuple[int, dict]], None, None]:
         self.__require_open()
 
@@ -155,7 +156,7 @@ class LinuxProcess(AbstractProcess):
         *,
         byte_length: int = 0,
         progress_information: bool = False,
-        memory_regions: Optional[Sequence[Dict]] = None,
+        memory_regions: Optional[Sequence[MemoryRegion]] = None,
     ) -> Generator[Union[int, Tuple[int, dict]], None, None]:
         self.__require_open()
         return search_addresses_by_pattern(
@@ -176,7 +177,7 @@ class LinuxProcess(AbstractProcess):
         not_between: bool = False,
         progress_information: bool = False,
         writeable_only: bool = False,
-        memory_regions: Optional[Sequence[Dict]] = None,
+        memory_regions: Optional[Sequence[MemoryRegion]] = None,
     ) -> Generator[Union[int, Tuple[int, dict]], None, None]:
         self.__require_open()
 

--- a/PyMemoryEditor/macos/functions.py
+++ b/PyMemoryEditor/macos/functions.py
@@ -9,14 +9,15 @@ import ctypes
 import logging
 import os
 import warnings
-from typing import Dict, Generator, List, Optional, Sequence, Tuple, Type, TypeVar, Union
+from typing import Generator, List, Optional, Sequence, Tuple, Type, TypeVar, Union
 
 from ..enums import ScanTypesEnum
 from ..process.module_info import ModuleInfo
 from ..process.region import (
     default_address_filter,
     default_scan_filter,
-    enrich_region,
+    MemoryRegion,
+    make_region,
 )
 from ..process.scanning import (
     iter_pattern_results,
@@ -118,7 +119,7 @@ def release_task(task: int) -> None:
         libsystem.mach_port_deallocate(mach_task_self_.value, task)
 
 
-def get_memory_regions(task: int) -> Generator[dict, None, None]:
+def get_memory_regions(task: int) -> Generator[MemoryRegion, None, None]:
     """
     Yield {address, size, struct} dicts describing each memory region of the task.
 
@@ -171,12 +172,10 @@ def get_memory_regions(task: int) -> Generator[dict, None, None]:
             info.reserved,
         )
 
-        yield enrich_region(
-            {
-                "address": address.value,
-                "size": size.value,
-                "struct": region_struct,
-            }
+        yield make_region(
+            address=address.value,
+            size=size.value,
+            struct=region_struct,
         )
 
         if size.value == 0:
@@ -283,7 +282,7 @@ def _mach_write(task: int, address: int, local_buffer_address: int, size: int) -
         # The address really is invalid — surface the original error.
         raise OSError("mach_vm_write failed: %s (kr=%d)" % (mach_error_message(kr), kr))
 
-    original_protection = region["struct"].Protection
+    original_protection = region.struct.Protection
 
     new_protection = VM_PROT_READ | VM_PROT_WRITE | VM_PROT_COPY
     protect_kr = libsystem.mach_vm_protect(task, address, size, 0, new_protection)
@@ -374,10 +373,10 @@ def _query_region(task: int, address: int):
     if not (addr.value <= address < addr.value + size.value):
         return None
 
-    return {
-        "address": addr.value,
-        "size": size.value,
-        "struct": MEMORY_BASIC_INFORMATION(
+    return make_region(
+        address=addr.value,
+        size=size.value,
+        struct=MEMORY_BASIC_INFORMATION(
             addr.value,
             size.value,
             info.protection,
@@ -385,7 +384,7 @@ def _query_region(task: int, address: int):
             info.shared,
             info.reserved,
         ),
-    }
+    )
 
 
 def read_process_memory(
@@ -490,7 +489,7 @@ def search_addresses_by_value(
     progress_information: bool = False,
     writeable_only: bool = False,
     *,
-    memory_regions: Optional[Sequence[Dict]] = None,
+    memory_regions: Optional[Sequence[MemoryRegion]] = None,
 ) -> Generator[Union[int, Tuple[int, dict]], None, None]:
     """
     Walk every readable region of the task and yield addresses whose value
@@ -511,7 +510,7 @@ def search_addresses_by_value(
         for region in source_regions
         if default_scan_filter(region, writeable_only=writeable_only)
     ]
-    filtered_regions.sort(key=lambda region: region["address"])
+    filtered_regions.sort(key=lambda region: region.address)
 
     yield from iter_search_results(
         filtered_regions,
@@ -814,7 +813,7 @@ def search_addresses_by_pattern(
     *,
     byte_length: int = 0,
     progress_information: bool = False,
-    memory_regions: Optional[Sequence[Dict]] = None,
+    memory_regions: Optional[Sequence[MemoryRegion]] = None,
 ) -> Generator[Union[int, Tuple[int, dict]], None, None]:
     """
     AOB scan against every readable region of the target task. See
@@ -829,7 +828,7 @@ def search_addresses_by_pattern(
     filtered_regions = [
         region for region in source_regions if default_scan_filter(region)
     ]
-    filtered_regions.sort(key=lambda region: region["address"])
+    filtered_regions.sort(key=lambda region: region.address)
 
     yield from iter_pattern_results(
         filtered_regions,
@@ -847,7 +846,7 @@ def search_values_by_addresses(
     bufflength: int,
     addresses: Sequence[int],
     *,
-    memory_regions: Optional[Sequence[Dict]] = None,
+    memory_regions: Optional[Sequence[MemoryRegion]] = None,
     raise_error: bool = False,
 ) -> Generator[Tuple[int, Optional[T]], None, None]:
     """

--- a/PyMemoryEditor/macos/process.py
+++ b/PyMemoryEditor/macos/process.py
@@ -7,6 +7,7 @@ from ..enums import ScanTypesEnum
 from ..process import AbstractProcess
 from ..process.errors import ClosedProcess
 from ..process.module_info import ModuleInfo
+from ..process.region import MemoryRegion
 from ..process.thread_info import ThreadInfo
 from ..util import resolve_bufflength
 
@@ -175,7 +176,7 @@ class MacProcess(AbstractProcess):
         addresses: Sequence[int],
         *,
         raise_error: bool = False,
-        memory_regions: Optional[Sequence[Dict]] = None,
+        memory_regions: Optional[Sequence[MemoryRegion]] = None,
     ) -> Generator[Tuple[int, Optional[T]], None, None]:
         self.__require_open()
         return search_values_by_addresses(
@@ -196,7 +197,7 @@ class MacProcess(AbstractProcess):
         *,
         progress_information: bool = False,
         writeable_only: bool = False,
-        memory_regions: Optional[Sequence[Dict]] = None,
+        memory_regions: Optional[Sequence[MemoryRegion]] = None,
     ) -> Generator[Union[int, Tuple[int, dict]], None, None]:
         self.__require_open()
 
@@ -222,7 +223,7 @@ class MacProcess(AbstractProcess):
         *,
         byte_length: int = 0,
         progress_information: bool = False,
-        memory_regions: Optional[Sequence[Dict]] = None,
+        memory_regions: Optional[Sequence[MemoryRegion]] = None,
     ) -> Generator[Union[int, Tuple[int, dict]], None, None]:
         self.__require_open()
         return search_addresses_by_pattern(
@@ -243,7 +244,7 @@ class MacProcess(AbstractProcess):
         not_between: bool = False,
         progress_information: bool = False,
         writeable_only: bool = False,
-        memory_regions: Optional[Sequence[Dict]] = None,
+        memory_regions: Optional[Sequence[MemoryRegion]] = None,
     ) -> Generator[Union[int, Tuple[int, dict]], None, None]:
         self.__require_open()
 

--- a/PyMemoryEditor/macos/types.py
+++ b/PyMemoryEditor/macos/types.py
@@ -99,8 +99,8 @@ TASK_DYLD_INFO_COUNT = sizeof(task_dyld_info_data_t) // _NATURAL_T_SIZE
 class MEMORY_BASIC_INFORMATION(Structure):
     """
     Cross-platform-compatible view of a memory region exposed via
-    `process.get_memory_regions()["struct"]`. Mirrors the Linux/Windows
-    structures shipped by PyMemoryEditor.
+    ``MemoryRegion.struct`` (see ``PyMemoryEditor.MemoryRegion``). Mirrors the
+    Linux/Windows structures shipped by PyMemoryEditor.
     """
 
     _fields_ = [

--- a/PyMemoryEditor/process/abstract.py
+++ b/PyMemoryEditor/process/abstract.py
@@ -19,7 +19,7 @@ from typing import (
 from ..enums import ScanTypesEnum
 from .info import ProcessInfo
 from .module_info import ModuleInfo
-from .scanning import _PRESORTED_KEY
+from .region import MemoryRegion, MemoryRegionSnapshot
 from .thread_info import ThreadInfo
 
 if TYPE_CHECKING:
@@ -89,10 +89,15 @@ class AbstractProcess(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def get_memory_regions(self) -> Generator[dict, None, None]:
+    def get_memory_regions(self) -> Generator[MemoryRegion, None, None]:
         """
-        Generates dictionaries with the address, size and other
-        information of each memory region used by the process.
+        Yield a :class:`~PyMemoryEditor.MemoryRegion` for every memory region
+        the process owns.
+
+        Each region carries its base ``address`` and ``size`` plus the portable
+        flags ``is_readable`` / ``is_writable`` / ``is_executable`` /
+        ``is_shared``, the backing file ``path`` (when known), and the
+        platform-specific ``struct`` for advanced introspection.
         """
         raise NotImplementedError()
 
@@ -144,27 +149,26 @@ class AbstractProcess(ABC):
             return None
         return min(threads, key=lambda t: t.tid)
 
-    def snapshot_memory_regions(self) -> List[Dict]:
+    def snapshot_memory_regions(self) -> MemoryRegionSnapshot:
         """
         Return a materialized snapshot of the process memory regions.
 
-        Pass the result as the `memory_regions` keyword to subsequent calls of
-        `search_by_value`, `search_by_value_between` or `search_by_addresses`
-        to skip the region enumeration. Useful for "scan → refine → refine"
-        workflows where the region map doesn't change between calls.
+        Pass the result as the ``memory_regions`` keyword to subsequent calls of
+        ``search_by_value``, ``search_by_value_between`` or
+        ``search_by_addresses`` to skip the region enumeration. Useful for
+        "scan → refine → refine" workflows where the region map doesn't change
+        between calls.
 
-        Regions are pre-sorted by base address and tagged so that the helper
-        functions in ``process.scanning`` skip their per-call ``sorted(...)``
-        step on reuse. Don't reorder the returned list manually; if you must
-        slice or filter, pass the result of ``sorted(my_slice, key=...)`` (or
-        an unsorted slice) — the helpers re-sort defensively when the tag is
-        missing.
+        The returned :class:`MemoryRegionSnapshot` is pre-sorted by base
+        address; the scan helpers in ``process.scanning`` detect this via
+        ``isinstance`` and skip their per-call ``sorted(...)`` step on reuse.
+        Slicing or filtering with a list comprehension drops the
+        ``MemoryRegionSnapshot`` type (you get a plain ``list``) — the helpers
+        then re-sort defensively, which is safe but slower for very large
+        region maps.
         """
-        regions = list(self.get_memory_regions())
-        regions.sort(key=lambda region: region["address"])
-        for region in regions:
-            region[_PRESORTED_KEY] = True
-        return regions
+        regions = sorted(self.get_memory_regions(), key=lambda region: region.address)
+        return MemoryRegionSnapshot(regions)
 
     @abstractmethod
     def search_by_addresses(
@@ -174,7 +178,7 @@ class AbstractProcess(ABC):
         addresses: Sequence[int],
         *,
         raise_error: bool = False,
-        memory_regions: Optional[Sequence[Dict]] = None,
+        memory_regions: Optional[Sequence[MemoryRegion]] = None,
     ) -> Generator[Tuple[int, Optional[T]], None, None]:
         """
         Search the whole memory space, accessible to the process,
@@ -195,7 +199,7 @@ class AbstractProcess(ABC):
         *,
         progress_information: bool = False,
         writeable_only: bool = False,
-        memory_regions: Optional[Sequence[Dict]] = None,
+        memory_regions: Optional[Sequence[MemoryRegion]] = None,
     ) -> Generator[Union[int, Tuple[int, dict]], None, None]:
         """
         Search the whole memory space, accessible to the process,
@@ -221,7 +225,7 @@ class AbstractProcess(ABC):
         *,
         byte_length: int = 0,
         progress_information: bool = False,
-        memory_regions: Optional[Sequence[Dict]] = None,
+        memory_regions: Optional[Sequence[MemoryRegion]] = None,
     ) -> Generator[Union[int, Tuple[int, dict]], None, None]:
         """
         Scan the target's memory for a byte pattern (AOB) — the Cheat Engine /
@@ -253,7 +257,7 @@ class AbstractProcess(ABC):
         not_between: bool = False,
         progress_information: bool = False,
         writeable_only: bool = False,
-        memory_regions: Optional[Sequence[Dict]] = None,
+        memory_regions: Optional[Sequence[MemoryRegion]] = None,
     ) -> Generator[Union[int, Tuple[int, dict]], None, None]:
         """
         Search the whole memory space, accessible to the process,
@@ -492,7 +496,7 @@ class AbstractProcess(ABC):
         writable_only: bool = True,
         static_ranges: Optional[Sequence[Tuple[int, int]]] = None,
         max_results: Optional[int] = None,
-        memory_regions: Optional[Sequence[Dict]] = None,
+        memory_regions: Optional[Sequence[MemoryRegion]] = None,
         progress_callback: Optional["Callable[[float], None]"] = None,
     ) -> Generator["PointerPath", None, None]:
         """
@@ -568,15 +572,15 @@ class AbstractProcess(ABC):
 
         # Pointers may point anywhere readable; chain hops live in writable
         # memory (the program writes them) unless the caller opts into read-only.
-        readable = [r for r in memory_regions if r.get("is_readable", True)]
+        readable = [r for r in memory_regions if r.is_readable]
         mapped_ranges = AddressRanges(
-            [(r["address"], r["address"] + r["size"]) for r in readable]
+            [(r.address, r.address + r.size) for r in readable]
         )
 
         scan_regions = [
-            (r["address"], r["size"])
+            (r.address, r.size)
             for r in readable
-            if (r.get("is_writable", True) if writable_only else True)
+            if (r.is_writable if writable_only else True)
         ]
 
         # Image ranges drive both static-base detection and module naming. Each

--- a/PyMemoryEditor/process/region.py
+++ b/PyMemoryEditor/process/region.py
@@ -1,35 +1,33 @@
 # -*- coding: utf-8 -*-
 
 """
-Cross-platform helpers for memory-region introspection.
+Cross-platform memory-region descriptor and introspection helpers.
 
-`get_memory_regions()` on each backend returns a dict with `address`, `size`
-and `struct` keys. The shape of `struct` is platform-specific:
+The backend ``get_memory_regions()`` generators yield instances of
+:class:`MemoryRegion` — an immutable dataclass that carries:
 
-  - Win32: MEMORY_BASIC_INFORMATION_{32,64} with `Protect` (PAGE_* bitmask)
-    and `Type` (MEM_PRIVATE / MEM_IMAGE / MEM_MAPPED).
-  - Linux: MEMORY_BASIC_INFORMATION with `Privileges` (bytes "rwxp" / "rwxs").
-  - macOS: MEMORY_BASIC_INFORMATION with `Protection` (VM_PROT_* bitmask) and
-    `Shared` (1 when the region is backed by a shared object).
+  - ``address`` / ``size`` of the contiguous block,
+  - the portable booleans ``is_readable`` / ``is_writable`` / ``is_executable``
+    / ``is_shared``,
+  - the backing file ``path`` (when the platform exposes it cheaply),
+  - and the original platform descriptor in ``struct`` (a
+    ``MEMORY_BASIC_INFORMATION`` on Windows, the privileges-string struct on
+    Linux, the VM struct on macOS).
 
-Portable client code (and the bundled Qt app) only wants the booleans
-`is_readable`, `is_writable`, `is_executable`, `is_shared` plus a `path`.
-This module provides:
+Portable client code never touches ``struct`` — the booleans cover every
+read/write/execute/shared question. Backends use :func:`make_region` to build
+each instance with all fields populated in one call; the predicate helpers
+(``is_region_readable`` etc.) are still exposed for callers that want to apply
+the same rules to a hand-built struct.
 
-  - the four boolean predicates as functions of a region dict, and
-  - `enrich_region(region)` which adds them in place. Backends call this
-    inside their `get_memory_regions` loop so callers get the richer view
-    for free without having to know how to introspect each struct.
-
-The original `address`, `size`, and `struct` keys remain unchanged for
-backward compatibility — existing client code that reaches into the
-platform struct directly keeps working.
-
-Constants are imported from the per-OS enum modules instead of being
-hardcoded here. The enums themselves are pure-Python so the import is
-safe on every supported platform; only the matching predicate branch
-actually runs based on the struct shape passed in.
+A presorted snapshot of regions (the one returned by
+``snapshot_memory_regions()``) is a :class:`MemoryRegionSnapshot` — a thin
+``list`` subclass that signals to the scan helpers in
+``process.scanning`` that the per-call ``sorted(...)`` step can be skipped.
 """
+
+from dataclasses import dataclass, field
+from typing import Any, List
 
 from ..macos.types import VM_PROT_EXECUTE, VM_PROT_READ, VM_PROT_WRITE
 from ..win32.enums.memory_allocation_states import MemoryAllocationStatesEnum
@@ -49,91 +47,117 @@ _PAGE_EXECUTABLE_MASK = (
 )
 
 
-REGION_KEYS = (
-    "address",
-    "size",
-    "struct",
-    "is_readable",
-    "is_writable",
-    "is_executable",
-    "is_shared",
-    "path",
-)
+@dataclass(frozen=True)
+class MemoryRegion:
+    """A single memory region in a target process's address space.
+
+    :param address: base address of the region.
+    :param size: region size in bytes.
+    :param struct: platform-specific descriptor (``MEMORY_BASIC_INFORMATION``
+        on Windows / Linux; the macOS VM struct). Portable code should rely on
+        the boolean fields below instead of poking at this directly.
+    :param is_readable: ``True`` when the region can be read.
+    :param is_writable: ``True`` when the region can be written.
+    :param is_executable: ``True`` when the region contains executable code.
+    :param is_shared: ``True`` when the region is a shared/file-backed mapping.
+    :param path: best-effort path of the file backing the region, or ``""``
+        when unknown (Linux exposes this directly from ``/proc/<pid>/maps``;
+        Windows and macOS would need extra syscalls and report ``""``).
+    """
+
+    address: int
+    size: int
+    struct: Any = field(default=None, repr=False, compare=False)
+    is_readable: bool = False
+    is_writable: bool = False
+    is_executable: bool = False
+    is_shared: bool = False
+    path: str = ""
 
 
-def is_region_readable(region: dict) -> bool:
-    """True when the region is readable (no syscall — inspects the struct)."""
-    info = region["struct"]
+class MemoryRegionSnapshot(List[MemoryRegion]):
+    """A pre-sorted snapshot of memory regions.
 
+    Returned by :meth:`AbstractProcess.snapshot_memory_regions`. Behaves exactly
+    like a plain ``list[MemoryRegion]`` — the only purpose of the subclass is to
+    let the scanning helpers in ``process.scanning`` detect via ``isinstance``
+    that the input is already sorted by ``address`` and skip the per-call
+    ``sorted(...)`` step.
+
+    Slicing or filtering with a list comprehension drops the tag (the result is
+    a plain ``list``), which is the safe default: the helpers re-sort
+    defensively whenever the input is not a :class:`MemoryRegionSnapshot`.
+    """
+
+
+def is_region_readable(struct: Any) -> bool:
+    """True when the platform ``struct`` describes a readable region."""
     # Linux: privileges string contains 'r'.
-    if hasattr(info, "Privileges"):
-        return b"r" in bytes(info.Privileges)
+    if hasattr(struct, "Privileges"):
+        return b"r" in bytes(struct.Privileges)
 
     # macOS: VM_PROT_READ bit.
-    if hasattr(info, "Protection") and hasattr(info, "Shared"):
-        return (info.Protection & VM_PROT_READ) != 0
+    if hasattr(struct, "Protection") and hasattr(struct, "Shared"):
+        return (struct.Protection & VM_PROT_READ) != 0
 
     # Windows: Protect bitmask + State must be MEM_COMMIT.
-    if hasattr(info, "Protect") and hasattr(info, "State"):
-        if info.State != MemoryAllocationStatesEnum.MEM_COMMIT:
+    if hasattr(struct, "Protect") and hasattr(struct, "State"):
+        if struct.State != MemoryAllocationStatesEnum.MEM_COMMIT:
             return False
-        return (info.Protect & MemoryProtectionsEnum.PAGE_READABLE) != 0
+        return (struct.Protect & MemoryProtectionsEnum.PAGE_READABLE) != 0
 
     return False
 
 
-def is_region_writable(region: dict) -> bool:
-    info = region["struct"]
+def is_region_writable(struct: Any) -> bool:
+    """True when the platform ``struct`` describes a writable region."""
+    if hasattr(struct, "Privileges"):
+        return b"w" in bytes(struct.Privileges)
 
-    if hasattr(info, "Privileges"):
-        return b"w" in bytes(info.Privileges)
+    if hasattr(struct, "Protection") and hasattr(struct, "Shared"):
+        return (struct.Protection & VM_PROT_WRITE) != 0
 
-    if hasattr(info, "Protection") and hasattr(info, "Shared"):
-        return (info.Protection & VM_PROT_WRITE) != 0
-
-    if hasattr(info, "Protect") and hasattr(info, "State"):
-        if info.State != MemoryAllocationStatesEnum.MEM_COMMIT:
+    if hasattr(struct, "Protect") and hasattr(struct, "State"):
+        if struct.State != MemoryAllocationStatesEnum.MEM_COMMIT:
             return False
-        return (info.Protect & MemoryProtectionsEnum.PAGE_READWRITEABLE) != 0
+        return (struct.Protect & MemoryProtectionsEnum.PAGE_READWRITEABLE) != 0
 
     return False
 
 
-def is_region_executable(region: dict) -> bool:
-    info = region["struct"]
+def is_region_executable(struct: Any) -> bool:
+    """True when the platform ``struct`` describes an executable region."""
+    if hasattr(struct, "Privileges"):
+        return b"x" in bytes(struct.Privileges)
 
-    if hasattr(info, "Privileges"):
-        return b"x" in bytes(info.Privileges)
+    if hasattr(struct, "Protection") and hasattr(struct, "Shared"):
+        return (struct.Protection & VM_PROT_EXECUTE) != 0
 
-    if hasattr(info, "Protection") and hasattr(info, "Shared"):
-        return (info.Protection & VM_PROT_EXECUTE) != 0
-
-    if hasattr(info, "Protect") and hasattr(info, "State"):
-        if info.State != MemoryAllocationStatesEnum.MEM_COMMIT:
+    if hasattr(struct, "Protect") and hasattr(struct, "State"):
+        if struct.State != MemoryAllocationStatesEnum.MEM_COMMIT:
             return False
-        return (info.Protect & _PAGE_EXECUTABLE_MASK) != 0
+        return (struct.Protect & _PAGE_EXECUTABLE_MASK) != 0
 
     return False
 
 
-def is_region_shared(region: dict) -> bool:
-    info = region["struct"]
-
-    if hasattr(info, "Privileges"):
+def is_region_shared(struct: Any) -> bool:
+    """True when the platform ``struct`` describes a shared mapping."""
+    if hasattr(struct, "Privileges"):
         # Linux: 's' for shared, 'p' for private — last char of the privileges string.
-        return b"s" in bytes(info.Privileges)
+        return b"s" in bytes(struct.Privileges)
 
-    if hasattr(info, "Shared"):
-        return bool(info.Shared)
+    if hasattr(struct, "Shared"):
+        return bool(struct.Shared)
 
-    if hasattr(info, "Type"):
+    if hasattr(struct, "Type"):
         # Windows: MEM_MAPPED indicates a file-backed shared mapping.
-        return info.Type == MemoryTypesEnum.MEM_MAPPED
+        return struct.Type == MemoryTypesEnum.MEM_MAPPED
 
     return False
 
 
-def region_path(region: dict) -> str:
+def region_path(struct: Any) -> str:
     """
     Best-effort path of the file backing the region, or "" when unknown.
 
@@ -141,11 +165,9 @@ def region_path(region: dict) -> str:
     macOS would require extra syscalls (GetMappedFileName / proc_regionfilename)
     that the backends don't currently make.
     """
-    info = region["struct"]
-
-    if hasattr(info, "Path"):
+    if hasattr(struct, "Path"):
         try:
-            raw = bytes(info.Path)
+            raw = bytes(struct.Path)
         except (TypeError, ValueError):
             return ""
         # Strip embedded NULs (the field is a fixed-size byte buffer).
@@ -160,20 +182,27 @@ def region_path(region: dict) -> str:
     return ""
 
 
-def enrich_region(region: dict) -> dict:
+def make_region(address: int, size: int, struct: Any) -> MemoryRegion:
+    """Build a fully-populated :class:`MemoryRegion` from a platform struct.
+
+    Backends call this once per region instead of constructing a dict and
+    enriching it in a second step. Computing every boolean upfront keeps the
+    public type immutable and removes a class of "what fields are populated?"
+    bugs that the old enrichment pattern was prone to.
     """
-    Populate `is_readable`, `is_writable`, `is_executable`, `is_shared`, `path`
-    on the given region dict in place, then return it.
-    """
-    region["is_readable"] = is_region_readable(region)
-    region["is_writable"] = is_region_writable(region)
-    region["is_executable"] = is_region_executable(region)
-    region["is_shared"] = is_region_shared(region)
-    region["path"] = region_path(region)
-    return region
+    return MemoryRegion(
+        address=address,
+        size=size,
+        struct=struct,
+        is_readable=is_region_readable(struct),
+        is_writable=is_region_writable(struct),
+        is_executable=is_region_executable(struct),
+        is_shared=is_region_shared(struct),
+        path=region_path(struct),
+    )
 
 
-def default_scan_filter(region: dict, *, writeable_only: bool = False) -> bool:
+def default_scan_filter(region: MemoryRegion, *, writeable_only: bool = False) -> bool:
     """
     Single source of truth for "which regions does a *value* / *pattern* scan
     walk by default".
@@ -181,8 +210,8 @@ def default_scan_filter(region: dict, *, writeable_only: bool = False) -> bool:
     Historically each backend rolled its own filter — Win32 excluded
     ``MEM_MAPPED`` via ``Type``, Linux excluded shared via ``'s'`` in
     privileges, and macOS excluded nothing — so the same call returned a
-    different set of matches per OS. The portable booleans on the region dict
-    (populated by :func:`enrich_region`) let one filter cover all three:
+    different set of matches per OS. The portable booleans on
+    :class:`MemoryRegion` let one filter cover all three:
 
     - must be readable (no syscall hops into unreadable pages),
     - if ``writeable_only``, must also be writable,
@@ -190,16 +219,16 @@ def default_scan_filter(region: dict, *, writeable_only: bool = False) -> bool:
       noise the caller virtually never wants in a value scan, and matching the
       Linux/Win32 historical behavior is the practical default.
     """
-    if not region.get("is_readable", False):
+    if not region.is_readable:
         return False
-    if writeable_only and not region.get("is_writable", False):
+    if writeable_only and not region.is_writable:
         return False
-    if region.get("is_shared", False):
+    if region.is_shared:
         return False
     return True
 
 
-def default_address_filter(region: dict) -> bool:
+def default_address_filter(region: MemoryRegion) -> bool:
     """
     Single source of truth for "which regions does an *address-list* read walk
     by default" (``search_by_addresses`` without a snapshot).
@@ -209,17 +238,18 @@ def default_address_filter(region: dict) -> bool:
     second-guessing whether the region is "interesting". The only requirement
     is that the region is readable — same on every OS.
     """
-    return bool(region.get("is_readable", False))
+    return region.is_readable
 
 
 __all__ = (
-    "REGION_KEYS",
+    "MemoryRegion",
+    "MemoryRegionSnapshot",
     "default_address_filter",
     "default_scan_filter",
-    "enrich_region",
     "is_region_executable",
     "is_region_readable",
     "is_region_shared",
     "is_region_writable",
+    "make_region",
     "region_path",
 )

--- a/PyMemoryEditor/process/scanning.py
+++ b/PyMemoryEditor/process/scanning.py
@@ -26,7 +26,6 @@ import logging
 from typing import (
     Any,
     Callable,
-    Dict,
     Generator,
     Iterable,
     Optional,
@@ -46,6 +45,7 @@ from ..util import (
     scan_memory,
     scan_memory_for_exact_value,
 )
+from .region import MemoryRegion, MemoryRegionSnapshot
 
 
 _logger = logging.getLogger("PyMemoryEditor")
@@ -64,31 +64,23 @@ _SearchingMethod = Callable[
 T = TypeVar("T")
 
 
-# Sentinel key on a region dict marking the dict as already address-sorted.
-# `iter_values_for_addresses` and `iter_search_results` consult this to skip
-# the per-call `sorted(...)` cost. ``snapshot_memory_regions()`` pre-sorts the
-# list and tags every region; pre-filtered slices that preserve order can
-# carry the tag through too.
-_PRESORTED_KEY = "_pymemoryeditor_presorted"
-
-
-def _ensure_sorted_by_address(memory_regions: Sequence[Dict]) -> Sequence[Dict]:
+def _ensure_sorted_by_address(
+    memory_regions: Sequence[MemoryRegion],
+) -> Sequence[MemoryRegion]:
     """
     Return ``memory_regions`` sorted by ``address``, reusing the input verbatim
-    when every region is already tagged with :data:`_PRESORTED_KEY`.
+    when it is a :class:`MemoryRegionSnapshot` (already address-sorted by
+    contract).
 
-    Tagging is purely advisory — falsifying it on an unsorted snapshot would
-    silently mis-walk regions, but no public API does that. The optimization
-    matters in tight refine-scan loops where snapshots are reused across many
-    ``search_by_addresses``/``search_by_value*`` calls.
+    The optimization matters in tight refine-scan loops where snapshots are
+    reused across many ``search_by_addresses`` / ``search_by_value*`` calls;
+    re-sorting a 100k-region list per call would dominate the runtime.
     """
     if not memory_regions:
         return memory_regions
-    # Cheap check: only inspect the first region; the tagging contract is
-    # all-or-nothing.
-    if memory_regions[0].get(_PRESORTED_KEY):
+    if isinstance(memory_regions, MemoryRegionSnapshot):
         return memory_regions
-    return sorted(memory_regions, key=lambda region: region["address"])
+    return sorted(memory_regions, key=lambda region: region.address)
 
 
 def _always_false(_exc: BaseException) -> bool:
@@ -98,7 +90,7 @@ def _always_false(_exc: BaseException) -> bool:
 
 def iter_values_for_addresses(
     addresses: Sequence[int],
-    memory_regions: Sequence[Dict],
+    memory_regions: Sequence[MemoryRegion],
     pytype: Type[T],
     bufflength: int,
     read_chunk: Callable[[int, int], "ctypes.Array"],
@@ -135,7 +127,7 @@ def iter_values_for_addresses(
         # Advance past regions that end before the current address.
         while region_index < len(sorted_regions):
             region = sorted_regions[region_index]
-            if current_address < region["address"] + region["size"]:
+            if current_address < region.address + region.size:
                 break
             region_index += 1
 
@@ -146,8 +138,8 @@ def iter_values_for_addresses(
             continue
 
         region = sorted_regions[region_index]
-        base_address = region["address"]
-        size = region["size"]
+        base_address = region.address
+        size = region.size
 
         # Address falls in the gap before this region (and no earlier region holds it).
         if current_address < base_address:
@@ -232,7 +224,7 @@ def iter_values_for_addresses(
 
 
 def iter_search_results(
-    memory_regions: Sequence[Dict],
+    memory_regions: Sequence[MemoryRegion],
     pytype: Type,
     bufflength: int,
     target_value_bytes: Union[bytes, Tuple[bytes, ...]],
@@ -270,7 +262,7 @@ def iter_search_results(
 
     memory_total = 0
     for region in memory_regions:
-        memory_total += region["size"]
+        memory_total += region.size
 
     if memory_total == 0:
         return
@@ -296,7 +288,7 @@ def iter_search_results(
     str_overlap = bufflength - 1 if pytype is str else 0
 
     for region in memory_regions:
-        address, size = region["address"], region["size"]
+        address, size = region.address, region.size
 
         for chunk_offset, chunk_size in iter_region_chunks(size, bufflength):
             chunk_address = address + chunk_offset
@@ -355,7 +347,7 @@ def iter_search_results(
 
 
 def iter_pattern_results(
-    memory_regions: Sequence[Dict],
+    memory_regions: Sequence[MemoryRegion],
     compiled_pattern: "Pattern[bytes]",
     pattern_length: int,
     read_chunk: Callable[[int, int], Any],
@@ -387,7 +379,7 @@ def iter_pattern_results(
 
     memory_total = 0
     for region in memory_regions:
-        memory_total += region["size"]
+        memory_total += region.size
 
     if memory_total == 0:
         return
@@ -395,7 +387,7 @@ def iter_pattern_results(
     checked_memory_size = 0
 
     for region in memory_regions:
-        address, size = region["address"], region["size"]
+        address, size = region.address, region.size
 
         for chunk_offset, chunk_size in iter_region_chunks(size, pattern_length):
             chunk_address = address + chunk_offset

--- a/PyMemoryEditor/win32/functions.py
+++ b/PyMemoryEditor/win32/functions.py
@@ -9,14 +9,15 @@
 import ctypes
 import ctypes.wintypes
 import logging
-from typing import Dict, Generator, Optional, Sequence, Tuple, Type, TypeVar, Union
+from typing import Generator, Optional, Sequence, Tuple, Type, TypeVar, Union
 
 from ..enums import ScanTypesEnum
 from ..process.module_info import ModuleInfo
 from ..process.region import (
+    MemoryRegion,
     default_address_filter,
     default_scan_filter,
-    enrich_region,
+    make_region,
 )
 from ..process.scanning import (
     iter_pattern_results,
@@ -230,9 +231,9 @@ def CloseProcessHandle(process_handle: int) -> int:
     return kernel32.CloseHandle(process_handle)
 
 
-def GetMemoryRegions(process_handle: int) -> Generator[dict, None, None]:
+def GetMemoryRegions(process_handle: int) -> Generator[MemoryRegion, None, None]:
     """
-    Generates dictionaries with the address and size of a region used by the process.
+    Yield a :class:`MemoryRegion` for every region in the target's address space.
 
     Picks the right MEMORY_BASIC_INFORMATION layout (32-bit vs 64-bit) for the
     target process to handle the WOW64 case (64-bit Python attached to a 32-bit
@@ -278,8 +279,8 @@ def GetMemoryRegions(process_handle: int) -> Generator[dict, None, None]:
             current_address += page_size
             continue
 
-        yield enrich_region(
-            {"address": current_address, "size": region.RegionSize, "struct": region}
+        yield make_region(
+            address=current_address, size=region.RegionSize, struct=region,
         )
 
         if region.RegionSize == 0:
@@ -384,7 +385,7 @@ def SearchAddressesByValue(
     progress_information: bool = False,
     writeable_only: bool = False,
     *,
-    memory_regions: Optional[Sequence[Dict]] = None,
+    memory_regions: Optional[Sequence[MemoryRegion]] = None,
 ) -> Generator[Union[int, Tuple[int, dict]], None, None]:
     """
     Search the whole memory space, accessible to the process,
@@ -407,7 +408,7 @@ def SearchAddressesByValue(
         for region in source_regions
         if default_scan_filter(region, writeable_only=writeable_only)
     ]
-    filtered_regions.sort(key=lambda region: region["address"])
+    filtered_regions.sort(key=lambda region: region.address)
 
     def read_chunk(address: int, size: int):
         # `_read_region` returns None on transient failures (page unmapped /
@@ -432,7 +433,7 @@ def SearchAddressesByPattern(
     *,
     byte_length: int = 0,
     progress_information: bool = False,
-    memory_regions: Optional[Sequence[Dict]] = None,
+    memory_regions: Optional[Sequence[MemoryRegion]] = None,
 ) -> Generator[Union[int, Tuple[int, dict]], None, None]:
     """
     AOB scan against every scannable region of the target process. See
@@ -448,7 +449,7 @@ def SearchAddressesByPattern(
     filtered_regions = [
         region for region in source_regions if default_scan_filter(region)
     ]
-    filtered_regions.sort(key=lambda region: region["address"])
+    filtered_regions.sort(key=lambda region: region.address)
 
     def read_chunk(address: int, size: int):
         # ``_read_region`` returns None on transient failures (page unmapped /
@@ -475,7 +476,7 @@ def SearchValuesByAddresses(
     bufflength: int,
     addresses: Sequence[int],
     *,
-    memory_regions: Optional[Sequence[Dict]] = None,
+    memory_regions: Optional[Sequence[MemoryRegion]] = None,
     raise_error: bool = False,
 ) -> Generator[Tuple[int, Optional[T]], None, None]:
     """

--- a/PyMemoryEditor/win32/process.py
+++ b/PyMemoryEditor/win32/process.py
@@ -9,6 +9,7 @@ from ..enums import ScanTypesEnum
 from ..process import AbstractProcess
 from ..process.errors import ClosedProcess
 from ..process.module_info import ModuleInfo
+from ..process.region import MemoryRegion
 from ..process.thread_info import ThreadInfo
 from .enums import ProcessOperationsEnum
 
@@ -191,7 +192,7 @@ class WindowsProcess(AbstractProcess):
         addresses: Sequence[int],
         *,
         raise_error: bool = False,
-        memory_regions: Optional[Sequence[Dict]] = None,
+        memory_regions: Optional[Sequence[MemoryRegion]] = None,
     ) -> Generator[Tuple[int, Optional[T]], None, None]:
         self.__require_open()
         self.__require_read()
@@ -213,7 +214,7 @@ class WindowsProcess(AbstractProcess):
         *,
         progress_information: bool = False,
         writeable_only: bool = False,
-        memory_regions: Optional[Sequence[Dict]] = None,
+        memory_regions: Optional[Sequence[MemoryRegion]] = None,
     ) -> Generator[Union[int, Tuple[int, dict]], None, None]:
         self.__require_open()
         self.__require_read()
@@ -240,7 +241,7 @@ class WindowsProcess(AbstractProcess):
         *,
         byte_length: int = 0,
         progress_information: bool = False,
-        memory_regions: Optional[Sequence[Dict]] = None,
+        memory_regions: Optional[Sequence[MemoryRegion]] = None,
     ) -> Generator[Union[int, Tuple[int, dict]], None, None]:
         self.__require_open()
         self.__require_read()
@@ -262,7 +263,7 @@ class WindowsProcess(AbstractProcess):
         not_between: bool = False,
         progress_information: bool = False,
         writeable_only: bool = False,
-        memory_regions: Optional[Sequence[Dict]] = None,
+        memory_regions: Optional[Sequence[MemoryRegion]] = None,
     ) -> Generator[Union[int, Tuple[int, dict]], None, None]:
         self.__require_open()
         self.__require_read()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # PyMemoryEditor
 
-A pure-Python library (built on [ctypes](https://docs.python.org/3/library/ctypes.html)) that lets you **inspect, modify and search the memory of any running process in a few lines of Python** — Cheat Engine workflows on Windows, Linux and macOS.
+A pure-Python library (built on [ctypes](https://docs.python.org/3/library/ctypes.html)) that lets you **inspect, modify and search the memory of any running process in a few lines of Python** — Cheat Engine workflows on Windows, Linux and macOS. 
+
+📖 Full guide at **[Read the Docs](https://pymemoryeditor.readthedocs.io)**.
 
 [![Python Package](https://github.com/JeanExtreme002/PyMemoryEditor/actions/workflows/python-package.yml/badge.svg)](https://github.com/JeanExtreme002/PyMemoryEditor/actions/workflows/python-package.yml)
 [![Pypi](https://img.shields.io/pypi/v/PyMemoryEditor)](https://pypi.org/project/PyMemoryEditor/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PyMemoryEditor
 
-A pure-Python library (built on [ctypes](https://docs.python.org/3/library/ctypes.html)) that lets you **inspect, modify and search the memory of any running process in a few lines of Python** — Cheat Engine-style scans, pointer chains and AOB search on Windows, Linux and macOS.
+A pure-Python library (built on [ctypes](https://docs.python.org/3/library/ctypes.html)) that lets you **inspect, modify and search the memory of any running process in a few lines of Python** — Cheat Engine workflows on Windows, Linux and macOS.
 
 [![Python Package](https://github.com/JeanExtreme002/PyMemoryEditor/actions/workflows/python-package.yml/badge.svg)](https://github.com/JeanExtreme002/PyMemoryEditor/actions/workflows/python-package.yml)
 [![Pypi](https://img.shields.io/pypi/v/PyMemoryEditor)](https://pypi.org/project/PyMemoryEditor/)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A pure-Python library (built on [ctypes](https://docs.python.org/3/library/ctype
 
 <p align="center">
   Tweak a value in a running game · inspect a live program's state ·
-  harvest data straight from RAM — <b>on Windows, Linux and macOS</b>.
+  harvest data straight from RAM.
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # PyMemoryEditor
-A Python library developed with [ctypes](https://docs.python.org/3/library/ctypes.html) to manipulate Windows, Linux and macOS processes (32-bit and 64-bit), <br>
-reading, writing and searching values in the process memory.
 
 [![Python Package](https://github.com/JeanExtreme002/PyMemoryEditor/actions/workflows/python-package.yml/badge.svg)](https://github.com/JeanExtreme002/PyMemoryEditor/actions/workflows/python-package.yml)
 [![Pypi](https://img.shields.io/pypi/v/PyMemoryEditor)](https://pypi.org/project/PyMemoryEditor/)
@@ -8,8 +6,6 @@ reading, writing and searching values in the process memory.
 [![Platforms](https://img.shields.io/badge/platforms-Windows%20%7C%20Linux%20%7C%20macOS-red)](https://pypi.org/project/PyMemoryEditor/)
 [![Python Version](https://img.shields.io/badge/python-3.10+-8A2BE2)](https://pypi.org/project/PyMemoryEditor/)
 [![Downloads](https://static.pepy.tech/personalized-badge/pymemoryeditor?period=total&units=international_system&left_color=grey&right_color=orange&left_text=Downloads)](https://pypi.org/project/PyMemoryEditor/)
-
----
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/JeanExtreme002/PyMemoryEditor/main/PyMemoryEditor/app/assets/icon.svg" alt="PyMemoryEditor logo" width="120" />
@@ -26,15 +22,6 @@ reading, writing and searching values in the process memory.
 </p>
 
 <p align="center">
-  <a href="#-quick-start">Quick Start</a> ·
-  <a href="#-usage-guide">Usage Guide</a> ·
-  <a href="#-troubleshooting">Troubleshooting</a> ·
-  <a href="#platform-notes">Platform Notes</a> ·
-  <a href="#-bonus-the-pymemoryeditor-app">The App</a> ·
-  <a href="#-contributing">Contributing</a>
-</p>
-
-<p align="center">
   <img src="https://raw.githubusercontent.com/JeanExtreme002/PyMemoryEditor/main/assets/screenshots/app.png" alt="PyMemoryEditor app attached to a running process" width="820" />
 </p>
 
@@ -44,467 +31,67 @@ reading, writing and searching values in the process memory.
 
 ---
 
-## Installation
-
-Available on PyPI for Windows, Linux and macOS — no native build step, no extra wheels.
+## Install
 
 ```bash
-$ pip install PyMemoryEditor
+pip install PyMemoryEditor
 ```
 
-To also install the bundled GUI app, use the `app` extra and launch it from any terminal:
+To also install the bundled GUI app (a Cheat Engine-style scanner), use the `app` extra:
 
 ```bash
-$ pip install "PyMemoryEditor[app]"
-$ pymemoryeditor
+pip install "PyMemoryEditor[app]"
+pymemoryeditor
 ```
 
 ---
 
-## 🚀 Quick Start
-
-Open a target process inside a `with` block, then read, write or scan its memory using
-plain Python types. Everything fits in a handful of lines:
+## A 60-second taste
 
 ```python
 from PyMemoryEditor import OpenProcess
 
-with OpenProcess(process_name="example.exe") as process:
-    value = 120
-
-    # Scan the whole process for every address holding that value.
-    for address in process.search_by_value(int, 4, value):
-        print(f"Found at 0x{address:X}")
-```
-
-Open a process by **process name** or **PID** — whichever you have:
-
-```python
-OpenProcess(process_name="notepad.exe")   # by process name
-OpenProcess(pid=1234)                     # by PID
-```
-
-### How it works in practice
-
-You rarely know the address of a value up front — you **find it by scanning**.
-The typical loop is the same one Cheat Engine made famous:
-
-1. **Scan** for a value you can see (e.g. your health is `100`) — you get back
-   many candidate addresses.
-2. **Let the value change** in the target (you take damage → `95`).
-3. **Refine**: keep only the addresses that now hold the new value. Repeat until
-   one address remains — that's your value.
-4. **Read, write or freeze** it.
-
-```python
 with OpenProcess(process_name="game.exe") as process:
-    # 1. First scan — every address currently holding 100.
-    candidates = list(process.search_by_value(int, 4, 100))
 
-    # 3. After the value drops to 95 in-game, keep only the matches that agree.
-    survivors = [
-        address
-        for address, value in process.search_by_addresses(int, 4, candidates)
-        if value == 95
-    ]
+    # Scan the whole process for every address holding the value 100.
+    for address in process.search_by_value(int, 4, 100):
+        print(f"Found at 0x{address:X}")
 
-    # 4. Overwrite the survivors back to a high value.
-    for address in survivors:
-        process.write_process_memory(address, int, 4, 9999)
+    # Write a new value at a known address.
+    process.write_process_memory(0x006A9EC0, int, 4, 9999)
 ```
 
-> For big targets, cache the region map once and reuse it across scans — see
-> [the refine-scan workflow](#the-refine-scan-workflow-recommended).
+That's it — read, write or scan another process in three lines, the same way on every platform.
 
 ---
 
-## 📚 Usage Guide
-
-### Reading and writing memory
-
-The building blocks are `read_process_memory` and `write_process_memory`. Numeric types
-(`int`, `float`, `bool`) infer the buffer length automatically; `str` and `bytes`
-need an explicit size.
-
-```python
-from PyMemoryEditor import OpenProcess
-
-# By default OpenProcess opens a read+write handle, 
-# so no permission needed for the common case.
-with OpenProcess(process_name="notepad.exe") as process:
-    address = 0x0005000C
-
-    # Read: 4 bytes inferred for int.
-    value = process.read_process_memory(address, int)
-
-    # Write: same — pass None to use the default width.
-    process.write_process_memory(address, int, None, value + 7)
-
-    # Strings require an explicit size:
-    name = process.read_process_memory(address, str, 32)
-```
-
-### 🔍 Searching for a value
-
-Look up a value anywhere in memory and stream every match:
-
-```python
-for address in process.search_by_value(int, 4, target_value):
-    print(f"Found address: 0x{address:X}")
-```
-
-#### Comparison modes — pick one of eight
-
-The default is `EXACT_VALUE`, but you can swap in any `ScanTypesEnum` mode:
-
-<details>
-<summary>Click to see all eight modes</summary>
-
-| Mode | Description |
-| --- | --- |
-| `EXACT_VALUE` | Value equals the target. *(default)* |
-| `NOT_EXACT_VALUE` | Value is anything **but** the target. |
-| `BIGGER_THAN` | Value is strictly greater than the target. |
-| `SMALLER_THAN` | Value is strictly less than the target. |
-| `BIGGER_THAN_OR_EXACT_VALUE` | `value ≥ target` |
-| `SMALLER_THAN_OR_EXACT_VALUE` | `value ≤ target` |
-| `VALUE_BETWEEN` | `min ≤ value ≤ max` (use `search_by_value_between`) |
-| `NOT_VALUE_BETWEEN` | Value falls **outside** the given range. |
-
-</details>
-
-```python
-from PyMemoryEditor import ScanTypesEnum
-
-for address in process.search_by_value(int, 4, target, scan_type=ScanTypesEnum.BIGGER_THAN):
-    ...
-
-for address in process.search_by_value_between(int, 4, min_value, max_value):
-    ...
-```
-
-All of these work with strings too — just remember that for `bytes` the comparison
-depends on your system's `byteorder`.
-
-#### Progress information
-
-For long scans, the same methods can yield progress alongside each address:
-
-```python
-for address, info in process.search_by_value(int, 4, target, progress_information=True):
-    print(f"Address: 0x{address:<10X} | Progress: {info['progress'] * 100:.1f}%")
-```
-
-### The refine-scan workflow *(recommended)*
-
-For the classic Cheat-Engine loop — *"first scan → restrict → restrict"* — enumerate
-the memory regions **once** and reuse the snapshot across every subsequent call. On
-heavy targets (browsers, JVMs with 100 000+ regions) this is a huge win, because the
-per-call region enumeration is the dominant cost otherwise.
-
-```python
-with OpenProcess(pid=1234) as process:
-    regions = process.snapshot_memory_regions()
-
-    # First pass — every address holding 100.
-    candidates = list(process.search_by_value(int, None, 100, memory_regions=regions))
-
-    # Refine — keep only those that now hold 95.
-    refined = [
-        addr
-        for addr, value in process.search_by_addresses(int, None, candidates, memory_regions=regions)
-        if value == 95
-    ]
-```
-
-All of `snapshot_memory_regions()`, `search_by_value`, `search_by_value_between` and
-`search_by_addresses` accept the same `memory_regions=` keyword. Pass an empty list
-(`[]`) to explicitly scan nothing.
-
-### Reading many addresses efficiently
-
-If you have a long list of addresses to read, `search_by_addresses` is *far* faster
-than calling `read_process_memory` in a loop — it reads each memory page only once
-and pulls every requested address out of it, slashing the number of syscalls.
-
-```python
-for address, value in process.search_by_addresses(int, 4, addresses_list):
-    print("Address", hex(address), "holds the value", value)
-```
-
-### 🗺️ Exploring the memory regions
-
-A process's address space is split into regions — contiguous blocks of memory,
-each with its own size and permissions. `get_memory_regions()` streams the
-address, size and metadata of every region the target owns:
-
-```python
-for region in process.get_memory_regions():
-    print(hex(region["address"]), region["size"], region["struct"])
-```
-
-### 📦 Listing the loaded modules
-
-A *module* is a file mapped into the process — the main executable plus every
-shared library it loaded (`.exe`/`.dll` on Windows, the binary and `.so` files
-on Linux, the Mach-O image and `.dylib` files on macOS). `get_modules()` yields
-a `ModuleInfo` for each one:
-
-```python
-for module in process.get_modules():
-    print(
-        module.name,
-        hex(module.base_address), 
-        module.size,
-        module.path
-    )
-    ...
-```
-
-
-### 🧵 Listing the process threads
-
-`get_threads()` yields a `ThreadInfo` for every thread running inside the
-target — useful for introspection (how many workers does it spawn? is the
-main thread still alive?). `main_thread` is a shortcut to the lowest-id one.
-
-```python
-for thread in process.get_threads():
-    print(thread.tid, thread.state, thread.priority)
-
-print("Main thread:", process.main_thread.tid)
-```
-
-> `tid` is the OS-native thread id (POSIX TID on Linux, thread id on Windows,
-> Mach port on macOS); `state` and `priority` are filled in where the platform
-> exposes them and are `None` otherwise.
-
-### 🎯 Pattern scan — grep for process memory
-
-Pass a raw `bytes` regular expression and the scanner applies it directly to
-memory, letting you locate *data* by its shape. The example below extracts
-every email address held in the target's memory.
-
-```python
-email = rb"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}"
-
-# byte_length is the maximum length of a single match (used to span chunk reads).
-for address in process.search_by_pattern(email, byte_length=128):
-    raw = process.read_process_memory(address, bytes, 128)
-    print(address, raw.split(b"\x00", 1)[0].decode("ascii", "replace"))
-```
-
-Patterns also work the other way — for *code*. Absolute addresses shift between
-builds, but **byte signatures remain stable**: provide an IDA-style hex string
-with `?` wildcards and `search_by_pattern` returns every match, the same
-technique Cheat Engine, IDA and Ghidra use to locate code that has moved.
-
-```python
-for address in process.search_by_pattern("48 8B ? ? 00 00 89 ?"):
-    print(f"Match at 0x{address:X}")
-```
-
-### 🔗 Pointer chains — resolve addresses that change every run
-
-A multi-level pointer is a static base plus a series of offsets —
-`module + offset → [+x] → [+y] → …`. Walk the whole chain in one line, then
-read or write the final address as usual:
-
-```python
-# module + 0x10F4F4 -> [+0x0] -> [+0x158]   (a value behind a two-level pointer)
-hp_address = process.resolve_pointer_chain(base + 0x10F4F4, [0x0, 0x158])
-hp = process.read_process_memory(hp_address, int, 4)
-```
-
-`ptr_size=4` for 32-bit targets, `ptr_size=8` (default) for 64-bit.
-
-### 📍 Live pointers — a handle you keep around
-
-`resolve_pointer_chain` finds an address once. A **`RemotePointer`** wraps that
-recipe in a reusable handle: read or write the value through `.value`, and it
-re-walks the chain every time — so the same handle keeps working even when the
-target moves things around in memory.
-
-```python
-# A handle to the player's HP, behind a two-level pointer.
-hp_ptr = process.get_pointer(address, pytype=int, bufflength=4)
-
-print(hp_ptr.value)   # read it
-hp_ptr.value = 9999   # write it
-```
-
-You can do pointer math too: `hp_ptr + 4` gives a **new** handle 4 bytes further
-along (handy when values sit side by side), without touching memory. Omit the
-offsets to wrap an address you already have — e.g. one found by a scan.
-
-```python
-# Mana is stored right after HP, so just step 4 bytes forward.
-mp_ptr = hp_ptr + 4
-print(mp_ptr.value)
-```
-
-### 🧭 Pointer scan — find a pointer that survives restarts
-
-A scanned address is gone the next launch — the OS loads everything somewhere new every
-time (ASLR). A **pointer chain** is the cure, but where do you *get* the chain?
-You **pointer-scan** for it: give the value's address **right now** and the library finds
-the static paths (`module + offsets`) that lead to it — the inverse of `resolve_pointer_chain`.
-
-```python
-# The value is at this address right now (e.g. from search_by_value).
-for path in process.scan_pointer_paths(0x1FA3C140):
-    print(path)                          # "game.exe"+0x10F4F4 -> [+0x0] -> +0x158
-    print(hex(path.resolve(process)))    # walk it -> the current address
-```
-
-Each result is a `PointerPath` you can keep: `path.to_pointer(process)` turns it into a
-live `RemotePointer`, and `path.rebase(process)` re-anchors it after a restart.
-
-> A first scan usually finds **many** candidates. Start narrow and widen only if needed —
-> `scan_pointer_paths(addr, max_depth=2, max_offset=0x100)`. Depth is the big cost.
-
-#### Narrowing down to the real one
-
-The reliable pointers are the ones that keep working after the value moves. So you
-**save a scan, restart the target, and rescan** — keeping only the paths that still land
-on the value. Repeat a couple of times and a handful of solid pointers remain:
-
-```python
-# Run 1 — scan and save.
-pointer_paths = process.scan_pointer_paths(address)
-process.save_pointer_paths(pointer_paths, "scan1.json")
-
-# …close the target, restart it, find the value's new address again…
-
-# Run 2 — keep only the saved paths that still reach it.
-survivors = process.rescan_pointer_paths("scan1.json", new_address)
-process.save_pointer_paths(survivors, "scan2.json")
-```
-
-Prefer working from independent scans? Save one per run, then **intersect** them — the
-paths present in *every* file are your stable pointers (no live address needed):
-
-```python
-stable = process.compare_pointer_scans("scan1.json", "scan2.json", "scan3.json")
-```
-
-Once you're down to one, use it forever — `path.rebase(process).to_pointer(process)`
-re-resolves itself on every read/write, so it just works in any future run.
-
-### 🧱 Allocating memory in the target
-
-Reserve a fresh block inside the target process, write to it like any other
-address, then release it. The library remembers each allocation's size, so
-`free_memory(address)` works without you tracking it:
-
-```python
-address = process.allocate_memory(64)             # base of a new 64-byte region
-process.write_process_memory(address, int, 4, 1337)
-process.free_memory(address)                       # release it
-```
-
-`allocate_memory` takes an optional, platform-specific `permission` (a `PAGE_*`
-value on Windows — default `PAGE_EXECUTE_READWRITE`; a `VM_PROT_*` bitmask on
-macOS — default read+write), mirroring `OpenProcess(permission=...)`.
-
-> [!NOTE]
-> **Linux is not supported here.** It has no syscall to allocate memory in
-> another process's address space (`mmap` only affects the calling process);
-> doing so would require a ptrace-based engine to make the target call `mmap`
-> itself. Both methods raise `NotImplementedError` on Linux. Windows
-> (`VirtualAllocEx`/`VirtualFreeEx`) and macOS
-> (`mach_vm_allocate`/`mach_vm_deallocate`) are fully supported.
-
----
-
-## Platform Notes
-
-PyMemoryEditor abstracts away the OS, but the OS still gets a say in **what you're allowed to touch**. Here's the short version per platform.
-
-<details>
-<summary><b>🪟 Windows</b> — works out of the box for most cases</summary>
-
-- Process names are matched case-insensitively in practice. Pass `case_sensitive=False`
-  to follow the OS convention.
-- The `permission=` kwarg maps directly to the `PROCESS_*` flags of `OpenProcess`.
-  The default is read+write (`PROCESS_VM_READ | PROCESS_VM_WRITE |
-  PROCESS_VM_OPERATION | PROCESS_QUERY_INFORMATION`) — pass a narrower mask if you
-  want a read-only handle.
-
-</details>
-
-<details>
-<summary><b>🐧 Linux</b> — governed by <code>ptrace_scope</code></summary>
-
-- The `permission` argument is ignored — the library uses `process_vm_readv` /
-  `process_vm_writev`.
-- Access depends on `ptrace_scope` and process ownership. If the target is **not**
-  a child of the caller and `ptrace_scope=1` (the common default), you'll see a
-  `PermissionError`. Run as root or relax
-  `/proc/sys/kernel/yama/ptrace_scope`.
-
-</details>
-
-<details>
-<summary><b>🍎 macOS</b> — governed by Mach entitlements</summary>
-
-- The `permission` argument is ignored — the library uses the Mach VM APIs
-  (`task_for_pid`, `mach_vm_read_overwrite`, `mach_vm_write`, `mach_vm_region`).
-- Opening **another** process requires the Python binary to be signed with the
-  `com.apple.security.cs.debugger` entitlement (or SIP disabled and running as root).
-- Opening the **current** process always works — handy for self-inspection and tests.
-
-> [!WARNING]
-> **macOS write side effect.** `write_process_memory` on a read-only page transparently
-> elevates the page protection via `mach_vm_protect`, performs the write, and tries to
-> restore the original protection. **If the restore step fails** (e.g. the target task
-> disappears mid-call), the library emits a `ResourceWarning` and the target page is
-> left more permissive than it started. Treat the warning as a signal to investigate.
-> The Win32 and Linux backends do not have this property: protection elevation is
-> opt-in on Windows (`PROCESS_VM_OPERATION`), and Linux does not need protection
-> changes for `process_vm_writev`.
-
-</details>
-
----
-
-## 🎁 Bonus: The PyMemoryEditor App
-
-> A **Cheat Engine-style** memory scanner, included for free with every install.
-
-PyMemoryEditor isn't just a library — it also ships with a polished cross-platform GUI built on **PySide6 (Qt for Python)**, so you can play with everything the library does without writing a single line of code. Launch it from any terminal:
-
-```bash
-$ pymemoryeditor
-```
-
-The app is a living demo of the library — it exercises every public surface (every `ScanTypesEnum` mode, every value type, scanning, refining, freezing values, the hex viewer, the memory map). If you're learning the API, it's the fastest way to see what's possible.
+## What's inside
 
 <table>
 <tr>
 <td width="50%" valign="top">
 
-**✨ What you get out of the box**
+**🐍 The Python library**
 
-- **Scanner** — eight scan modes, ranges, byte-signature or regex search
-- **Refine workflow** — *First Scan → Next Scan → Next Scan…* like Cheat Engine
-- **Cheat table** — freeze / write values, import/export as JSON
-- **Pointer scan** — find static pointers; export, rescan & compare to narrow them down;
-- **Memory map** — regions with R/W/X flags
-- **Hex viewer** — live dump with write-back
+- ✅ **Read & write** values (`int`, `float`, `bool`, `str`, `bytes`)
+- 🔍 **Value scan** with eight comparison modes
+- 🎯 **Pattern scan** (IDA-style AOB & regex)
+- 🔗 **Pointer chains** + a live `RemotePointer` handle
+- 🧭 **Pointer scan** — find static pointers that survive ASLR
+- 🗺️ **Memory map**, **modules**, **threads**
+- 🧱 **Allocate & free** remote memory (Windows / macOS)
 
 </td>
 <td width="50%" valign="top">
 
-**📦 Install the app extra** (adds PySide6):
+**🖥️ The bundled GUI app**
 
-```bash
-$ pip install "PyMemoryEditor[app]"
-```
-
-Then launch the app by running `pymemoryeditor` from any terminal. The library itself stays dependency-free.
-
-> Cross-platform dark theme. Single-keystroke shortcuts. Works on Windows, Linux and macOS.
+- 🎯 **Scanner** — every scan mode, ranges, regex/AOB search
+- 🔁 **Refine workflow** — First Scan → Next Scan…
+- 📋 **Cheat table** — freeze / write values, JSON import/export
+- 🔗 **Pointer scan** — export, rescan & compare
+- 🗺️ **Memory map** with R/W/X flags
+- 🔬 **Hex viewer** with write-back
 
 </td>
 </tr>
@@ -512,13 +99,33 @@ Then launch the app by running `pymemoryeditor` from any terminal. The library i
 
 ---
 
+## 📖 Documentation
+
+Full documentation lives at **[pymemoryeditor.readthedocs.io](https://pymemoryeditor.readthedocs.io)** — installation, the Cheat Engine workflow, every method and parameter, the GUI app guide, platform notes and troubleshooting.
+
+A quick map of where to go:
+
+<table>
+<tr><td><a href="docs/quickstart.md"><b>Quick Start</b></a></td><td>Open a process, read, write and run your first scan.</td></tr>
+<tr><td><a href="docs/guide/searching.md"><b>Searching memory</b></a></td><td>Value scans, ranges, refining results, the Cheat Engine loop.</td></tr>
+<tr><td><a href="docs/guide/pattern-scan.md"><b>Pattern scan</b></a></td><td>Find code/data with byte signatures (AOB) and regex.</td></tr>
+<tr><td><a href="docs/guide/pointers.md"><b>Pointers</b></a></td><td>Multi-level pointer chains and the live <code>RemotePointer</code>.</td></tr>
+<tr><td><a href="docs/guide/pointer-scan.md"><b>Pointer scan</b></a></td><td>Find static pointers that survive ASLR.</td></tr>
+<tr><td><a href="docs/app.md"><b>The GUI app</b></a></td><td>The bundled Cheat Engine-style scanner.</td></tr>
+<tr><td><a href="docs/api/openprocess.md"><b>API reference</b></a></td><td>Every public class, method and parameter.</td></tr>
+<tr><td><a href="docs/platform-notes.md"><b>Platform notes</b></a></td><td>Permissions and quirks on Windows, Linux and macOS.</td></tr>
+<tr><td><a href="docs/troubleshooting.md"><b>Troubleshooting</b></a></td><td>Common errors and how to fix them.</td></tr>
+</table>
+
+---
+
 ## What can I build with this?
 
-- **Debugging & introspection** — inspect live state without attaching a debugger.
-- **Observability tooling** — sample variables in a running process for telemetry.
-- **Security & reverse-engineering research** — on systems you own or are authorized to test.
-- **Personal game modding & speedrunning tools** — the classic Cheat-Engine use case.
-- **Learning** — the bundled app is a great teaching tool for how memory scanning works.
+- 🎮 **Game modding & speedrunning tools** — the classic Cheat Engine use case.
+- 🔬 **Debugging & introspection** — inspect live state without attaching a debugger.
+- 📊 **Observability tooling** — sample variables in a running process for telemetry.
+- 🔐 **Security & reverse-engineering research** — on systems you own or are authorized to test.
+- 🎓 **Learning** — the bundled app is a great teaching tool for how memory scanning works.
 
 > [!NOTE]
 > **Responsible use.** PyMemoryEditor talks to other processes through OS-level APIs.
@@ -526,52 +133,11 @@ Then launch the app by running `pymemoryeditor` from any terminal. The library i
 
 ---
 
-## 🛟 Troubleshooting
-
-<b>`PermissionError` when opening another process</b> — the OS is denying access.
-This is the most common first hurdle:
-- **Windows:** run your terminal **as Administrator** for protected targets.
-- **Linux:** run as root, or relax `ptrace_scope`
-  (`sudo sysctl kernel.yama.ptrace_scope=0`). Opening your own process always works.
-- **macOS:** the Python binary must be signed with the
-  `com.apple.security.cs.debugger` entitlement (or SIP off + root). Opening the
-  *current* process always works — great for trying things out.
-
-<b>`ProcessNotFoundError`</b> — the name didn't match. Names are case-sensitive by
-default; try `OpenProcess(process_name="chrome", exact_match=False, case_sensitive=False)`
-for a fuzzy match, or pass the `pid=` directly.
-
-<b>`AmbiguousProcessNameError`</b> — more than one process matches. Pick one from the
-listed PIDs and pass `pid=` instead.
-
-<b>A scan returns nothing on Windows</b> — region enumeration needs
-`PROCESS_QUERY_INFORMATION`, which the default permission already includes. If you
-passed a custom `permission=` mask, make sure that flag is in it.
-
-<b>Reading an address gives garbage or raises `OSError`</b> — the page may have been
-freed between scan and read (normal during a live scan), or the value type / size
-is wrong. Wrap one-off reads in `try/except OSError` and double-check the byte width.
-
-Need more detail? The library logs to a standard `logging` logger named
-`"PyMemoryEditor"` (silent by default). Turn it on to see exactly which pages
-the library skips during a scan and why:
-
-```python
-import logging
-
-logging.basicConfig(level=logging.DEBUG)
-logging.getLogger("PyMemoryEditor").setLevel(logging.DEBUG)
-```
-
-> The bundled app exposes the same stream in its **Log Console** (Tools → Log Console).
-
----
-
 ## 🤝 Contributing
 
 Pull requests, bug reports and feature ideas are very welcome. Read
-[`CONTRIBUTING.md`](CONTRIBUTING.md) for the development setup, test layout and the
-small set of platform-specific quirks to be aware of.
+[`CONTRIBUTING.md`](CONTRIBUTING.md) for the development setup, test layout and
+the small set of platform-specific quirks to be aware of.
 
 If PyMemoryEditor helped your project, please ⭐ the repo — it's the easiest way to
 support the work and to help others discover the library.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PyMemoryEditor
 
+A pure-Python library (built on [ctypes](https://docs.python.org/3/library/ctypes.html)) that lets you **inspect, modify and search the memory of any running process in a few lines of Python** — Cheat Engine-style scans, pointer chains and AOB search on Windows, Linux and macOS.
+
 [![Python Package](https://github.com/JeanExtreme002/PyMemoryEditor/actions/workflows/python-package.yml/badge.svg)](https://github.com/JeanExtreme002/PyMemoryEditor/actions/workflows/python-package.yml)
 [![Pypi](https://img.shields.io/pypi/v/PyMemoryEditor)](https://pypi.org/project/PyMemoryEditor/)
 [![License](https://img.shields.io/pypi/l/PyMemoryEditor)](https://pypi.org/project/PyMemoryEditor/)

--- a/docs/api/enums.md
+++ b/docs/api/enums.md
@@ -1,0 +1,112 @@
+# Enums
+
+## `ScanTypesEnum`
+
+Comparison modes for `search_by_value` and `search_by_value_between`.
+
+```python
+from PyMemoryEditor import ScanTypesEnum
+```
+
+<table>
+<tr><th>Member</th><th>Value</th><th>Matches when…</th></tr>
+<tr><td><code>EXACT_VALUE</code></td><td><code>0</code></td><td>value == target <em>(default)</em></td></tr>
+<tr><td><code>NOT_EXACT_VALUE</code></td><td><code>1</code></td><td>value != target</td></tr>
+<tr><td><code>BIGGER_THAN</code></td><td><code>2</code></td><td>value &gt; target</td></tr>
+<tr><td><code>SMALLER_THAN</code></td><td><code>3</code></td><td>value &lt; target</td></tr>
+<tr><td><code>BIGGER_THAN_OR_EXACT_VALUE</code></td><td><code>4</code></td><td>value &ge; target</td></tr>
+<tr><td><code>SMALLER_THAN_OR_EXACT_VALUE</code></td><td><code>5</code></td><td>value &le; target</td></tr>
+<tr><td><code>VALUE_BETWEEN</code></td><td><code>6</code></td><td>min &le; value &le; max (used by <code>search_by_value_between</code>)</td></tr>
+<tr><td><code>NOT_VALUE_BETWEEN</code></td><td><code>7</code></td><td>value &lt; min or value &gt; max</td></tr>
+</table>
+
+### Example
+
+```python
+from PyMemoryEditor import OpenProcess, ScanTypesEnum
+
+with OpenProcess(process_name="game.exe") as process:
+    for address in process.search_by_value(
+        int, 4, 1000, scan_type=ScanTypesEnum.BIGGER_THAN,
+    ):
+        print(hex(address))
+```
+
+---
+
+## `ProcessOperationsEnum` <small>(Windows only)</small>
+
+Bitmask of [process access rights](https://learn.microsoft.com/en-us/windows/win32/procthread/process-security-and-access-rights).
+Defined as `IntFlag` so members can be combined with `|`:
+
+```python
+from PyMemoryEditor import ProcessOperationsEnum
+
+mask = (
+    ProcessOperationsEnum.PROCESS_VM_READ
+    | ProcessOperationsEnum.PROCESS_QUERY_INFORMATION
+)
+```
+
+<table>
+<tr><th>Member</th><th>Hex</th><th>Required for</th></tr>
+<tr><td><code>PROCESS_TERMINATE</code></td><td><code>0x0001</code></td><td><code>TerminateProcess</code></td></tr>
+<tr><td><code>PROCESS_CREATE_THREAD</code></td><td><code>0x0002</code></td><td>Creating a thread</td></tr>
+<tr><td><code>PROCESS_VM_OPERATION</code></td><td><code>0x0008</code></td><td>Allocating / freeing / changing page protection</td></tr>
+<tr><td><code>PROCESS_VM_READ</code></td><td><code>0x0010</code></td><td><code>ReadProcessMemory</code></td></tr>
+<tr><td><code>PROCESS_VM_WRITE</code></td><td><code>0x0020</code></td><td><code>WriteProcessMemory</code></td></tr>
+<tr><td><code>PROCESS_DUP_HANDLE</code></td><td><code>0x0040</code></td><td>Duplicating a handle</td></tr>
+<tr><td><code>PROCESS_CREATE_PROCESS</code></td><td><code>0x0080</code></td><td>Creating a process</td></tr>
+<tr><td><code>PROCESS_SET_QUOTA</code></td><td><code>0x0100</code></td><td>Setting memory limits</td></tr>
+<tr><td><code>PROCESS_SET_INFORMATION</code></td><td><code>0x0200</code></td><td>Setting priority class, etc.</td></tr>
+<tr><td><code>PROCESS_QUERY_INFORMATION</code></td><td><code>0x0400</code></td><td><code>VirtualQueryEx</code>, token info</td></tr>
+<tr><td><code>PROCESS_SUSPEND_RESUME</code></td><td><code>0x0800</code></td><td>Suspend/resume the process</td></tr>
+<tr><td><code>PROCESS_QUERY_LIMITED_INFORMATION</code></td><td><code>0x1000</code></td><td>Limited info queries</td></tr>
+<tr><td><code>PROCESS_SET_LIMITED_INFORMATION</code></td><td><code>0x2000</code></td><td>Limited info set</td></tr>
+<tr><td><code>PROCESS_ALL_ACCESS</code></td><td><code>0x1FFFFF</code></td><td>Everything</td></tr>
+</table>
+
+### Default permission
+
+The default mask used by `OpenProcess` on Windows is:
+
+```python
+PROCESS_VM_READ | PROCESS_VM_WRITE | PROCESS_VM_OPERATION | PROCESS_QUERY_INFORMATION
+```
+
+This is enough for both read and write operations plus region enumeration
+(`VirtualQueryEx` needs `PROCESS_QUERY_INFORMATION`).
+
+---
+
+## `MemoryProtectionsEnum` <small>(Windows only)</small>
+
+The Win32 `PAGE_*` constants. Used as the `permission=` argument of
+`allocate_memory` and surfaced in `region["struct"].Protect`.
+
+```python
+from PyMemoryEditor.win32.enums.memory_protections import MemoryProtectionsEnum
+```
+
+<table>
+<tr><th>Member</th><th>Hex</th><th>Meaning</th></tr>
+<tr><td><code>PAGE_NOACCESS</code></td><td><code>0x01</code></td><td>Disables all access.</td></tr>
+<tr><td><code>PAGE_READONLY</code></td><td><code>0x02</code></td><td>Read-only.</td></tr>
+<tr><td><code>PAGE_READWRITE</code></td><td><code>0x04</code></td><td>Read + write.</td></tr>
+<tr><td><code>PAGE_WRITECOPY</code></td><td><code>0x08</code></td><td>Copy-on-write.</td></tr>
+<tr><td><code>PAGE_EXECUTE</code></td><td><code>0x10</code></td><td>Execute-only.</td></tr>
+<tr><td><code>PAGE_EXECUTE_READ</code></td><td><code>0x20</code></td><td>Read + execute.</td></tr>
+<tr><td><code>PAGE_EXECUTE_READWRITE</code></td><td><code>0x40</code></td><td>Read + write + execute. <em>(allocate_memory default)</em></td></tr>
+<tr><td><code>PAGE_EXECUTE_WRITECOPY</code></td><td><code>0x80</code></td><td>Read + execute + copy-on-write.</td></tr>
+<tr><td><code>PAGE_GUARD</code></td><td><code>0x100</code></td><td>Pages become guard pages.</td></tr>
+<tr><td><code>PAGE_NOCACHE</code></td><td><code>0x200</code></td><td>Non-cachable.</td></tr>
+<tr><td><code>PAGE_WRITECOMBINE</code></td><td><code>0x400</code></td><td>Write-combined.</td></tr>
+</table>
+
+### Convenience composites
+
+<table>
+<tr><th>Member</th><th>Includes</th></tr>
+<tr><td><code>PAGE_READABLE</code></td><td>Every PAGE_* that allows reads.</td></tr>
+<tr><td><code>PAGE_READWRITEABLE</code></td><td>Every PAGE_* that allows writes.</td></tr>
+</table>

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -1,0 +1,149 @@
+# Errors
+
+PyMemoryEditor defines a small exception hierarchy. All custom exceptions
+inherit from `PyMemoryEditorError`, so you can catch the whole library:
+
+```python
+from PyMemoryEditor import PyMemoryEditorError
+
+try:
+    with OpenProcess(process_name="game.exe") as process:
+        ...
+except PyMemoryEditorError as exc:
+    print("Library error:", exc)
+```
+
+## The hierarchy
+
+```text
+Exception
+└── PyMemoryEditorError
+    ├── ClosedProcess
+    ├── ProcessIDNotExistsError
+    ├── ProcessNotFoundError
+    └── AmbiguousProcessNameError
+```
+
+The library also raises **standard built-in exceptions** when they are the
+more idiomatic match (`PermissionError`, `OSError`, `TypeError`, `ValueError`,
+`NotImplementedError`).
+
+## Custom exceptions
+
+### `PyMemoryEditorError`
+
+Base class for every PyMemoryEditor-specific exception. Catch it to handle
+*any* library error.
+
+### `ClosedProcess`
+
+Raised when you call any method on a process whose handle has already been
+closed (manually or by leaving the `with` block).
+
+```python
+with OpenProcess(pid=1234) as process:
+    pass
+
+process.read_process_memory(0x1000, int)   # raises ClosedProcess
+```
+
+### `ProcessIDNotExistsError`
+
+Raised when the given `pid=` doesn't correspond to a running process.
+
+```{eval-rst}
+.. py:attribute:: pid
+   :type: int
+
+   The PID that was looked up.
+```
+
+### `ProcessNotFoundError`
+
+Raised when no running process matches the given `process_name=`.
+
+```{eval-rst}
+.. py:attribute:: process_name
+   :type: str
+
+   The process name that was looked up.
+```
+
+### `AmbiguousProcessNameError`
+
+Raised when **more than one** running process matches the given
+`process_name=` (typical when using `exact_match=False`).
+
+```{eval-rst}
+.. py:attribute:: process_name
+   :type: str
+   :no-index:
+
+   The process name that was looked up.
+
+.. py:attribute:: pids
+   :type: List[int]
+
+   PIDs of the matching processes — pick one and pass it via ``pid=``.
+```
+
+Example:
+
+```python
+from PyMemoryEditor import OpenProcess, AmbiguousProcessNameError
+
+try:
+    OpenProcess(process_name="chrome", exact_match=False)
+except AmbiguousProcessNameError as exc:
+    print("Multiple matches:", exc.pids)
+    process = OpenProcess(pid=exc.pids[0])
+```
+
+## Standard exceptions
+
+<table>
+<tr><th>Exception</th><th>When it's raised</th></tr>
+<tr><td><code>TypeError</code></td><td>Neither <code>process_name</code> nor <code>pid</code> provided to <code>OpenProcess</code>.</td></tr>
+<tr><td><code>ValueError</code></td><td>Invalid <code>pytype</code>, missing <code>bufflength</code> for <code>str</code>/<code>bytes</code>, invalid <code>ptr_size</code>, malformed pattern, etc.</td></tr>
+<tr><td><code>PermissionError</code></td><td>OS denied access to the target process or a specific region.</td></tr>
+<tr><td><code>OSError</code></td><td>Low-level read/write failure (e.g. page was freed between scan and read).</td></tr>
+<tr><td><code>NotImplementedError</code></td><td><code>allocate_memory</code> / <code>free_memory</code> on Linux.</td></tr>
+<tr><td><code>UserWarning</code></td><td><code>permission=</code> passed on a non-Windows platform (silently ignored).</td></tr>
+<tr><td><code>ResourceWarning</code></td><td>macOS: <code>mach_vm_protect</code> failed to restore a page's original protection after a write.</td></tr>
+</table>
+
+## Catching robustly
+
+A pattern that handles every realistic failure mode:
+
+```python
+from PyMemoryEditor import (
+    OpenProcess,
+    PyMemoryEditorError,
+    ProcessNotFoundError,
+    AmbiguousProcessNameError,
+)
+
+try:
+    with OpenProcess(process_name="game.exe") as process:
+        for address in process.search_by_value(int, 4, 100):
+            try:
+                value = process.read_process_memory(address, int)
+            except OSError:
+                continue   # the page disappeared mid-scan — keep going
+            print(hex(address), value)
+
+except ProcessNotFoundError:
+    print("The game isn't running.")
+except AmbiguousProcessNameError as exc:
+    print("Pick one PID:", exc.pids)
+except PermissionError:
+    print("OS denied access — see Platform Notes.")
+except PyMemoryEditorError as exc:
+    print("Library error:", exc)
+```
+
+```{seealso}
+- [Troubleshooting](../troubleshooting.md)
+- [Platform Notes](../platform-notes.md)
+```

--- a/docs/api/memory-region.md
+++ b/docs/api/memory-region.md
@@ -1,0 +1,120 @@
+# `MemoryRegion`
+
+A single memory region in a target process's address space.
+
+```python
+from PyMemoryEditor import MemoryRegion
+```
+
+`MemoryRegion` is a `@dataclass(frozen=True)` yielded by
+`process.get_memory_regions()`. Each instance describes one contiguous block
+of memory with its address, size, permissions and backing path.
+
+## Fields
+
+```{eval-rst}
+.. py:class:: MemoryRegion(address, size, struct=None, is_readable=False, is_writable=False, is_executable=False, is_shared=False, path="")
+
+   .. py:attribute:: address
+      :type: int
+
+      Base address of the region.
+
+   .. py:attribute:: size
+      :type: int
+
+      Region size in bytes.
+
+   .. py:attribute:: struct
+      :type: Any
+
+      Platform-specific descriptor. Portable code should rely on the boolean
+      fields below instead of poking at this directly. Shape varies:
+
+      - **Windows** — ``MEMORY_BASIC_INFORMATION_{32,64}`` with ``Protect``
+        (PAGE_* bitmask) and ``Type`` (``MEM_PRIVATE`` / ``MEM_IMAGE`` /
+        ``MEM_MAPPED``).
+      - **Linux** — small struct with ``Privileges`` (bytes like ``rwxp`` /
+        ``rwxs``).
+      - **macOS** — struct with ``Protection`` (``VM_PROT_*`` bitmask) and
+        ``Shared``.
+
+   .. py:attribute:: is_readable
+      :type: bool
+
+      ``True`` when the region can be read.
+
+   .. py:attribute:: is_writable
+      :type: bool
+
+      ``True`` when the region can be written.
+
+   .. py:attribute:: is_executable
+      :type: bool
+
+      ``True`` when the region contains executable code.
+
+   .. py:attribute:: is_shared
+      :type: bool
+
+      ``True`` when the region is a shared/file-backed mapping.
+
+   .. py:attribute:: path
+      :type: str
+
+      Best-effort path of the file backing the region, or ``""`` when
+      unknown. Linux exposes this directly from ``/proc/<pid>/maps``;
+      Windows and macOS would need extra syscalls and report ``""``.
+```
+
+## `MemoryRegionSnapshot`
+
+```{eval-rst}
+.. py:class:: MemoryRegionSnapshot
+
+   A pre-sorted snapshot of memory regions returned by
+   :py:meth:`AbstractProcess.snapshot_memory_regions`. Behaves exactly like a
+   plain ``list[MemoryRegion]`` — the only purpose of the subclass is to let
+   the scanning helpers detect via ``isinstance`` that the input is already
+   sorted by ``address`` and skip the per-call ``sorted(...)`` step.
+
+   Slicing or filtering with a list comprehension drops the
+   :py:class:`MemoryRegionSnapshot` type (you get a plain ``list``). The
+   scan helpers re-sort defensively whenever the input is not a
+   :py:class:`MemoryRegionSnapshot`, so this is safe but slightly slower for
+   very large region maps.
+```
+
+## Examples
+
+### Iterating regions
+
+```python
+with OpenProcess(process_name="game.exe") as process:
+    for region in process.get_memory_regions():
+        print(f"0x{region.address:016X}  {region.size:>12,}")
+```
+
+### Filtering by permission
+
+```python
+writable = [r for r in process.get_memory_regions() if r.is_writable]
+```
+
+### Building a snapshot for the refine loop
+
+```python
+snapshot = process.snapshot_memory_regions()
+assert isinstance(snapshot, MemoryRegionSnapshot)
+# Reuse across many scans:
+for addr in process.search_by_value(int, 4, 100, memory_regions=snapshot):
+    ...
+```
+
+```{seealso}
+- [Memory regions guide](../guide/memory-regions.md)
+- [Searching memory](../guide/searching.md) — uses the snapshot to skip
+  region enumeration on the refine loop.
+- [Utilities API](utilities.md) — low-level predicates `is_region_readable`
+  etc. for callers that hold a raw platform struct.
+```

--- a/docs/api/module-info.md
+++ b/docs/api/module-info.md
@@ -1,0 +1,87 @@
+# `ModuleInfo`
+
+A single module — executable or shared library — loaded in a process.
+
+```python
+from PyMemoryEditor import ModuleInfo
+```
+
+`ModuleInfo` is a `@dataclass(frozen=True)` returned by `process.get_modules()`.
+Each entry corresponds to a file mapped into the address space — the main
+executable plus every shared library it loaded (`.dll` on Windows, `.so` on
+Linux, `.dylib` on macOS).
+
+## Fields
+
+```{eval-rst}
+.. py:class:: ModuleInfo(name, path, base_address, size=0, raw=None)
+
+   .. py:attribute:: name
+      :type: str
+
+      File name of the module (e.g. ``"game.exe"``, ``"libc.so.6"``).
+
+   .. py:attribute:: path
+      :type: str
+
+      Full path of the backing file on disk when the OS exposes it; falls
+      back to ``name`` when only the name is available.
+
+   .. py:attribute:: base_address
+      :type: int
+
+      Address where the module is loaded for this run. Combine it with a
+      static offset (``base_address + offset``) to reach a known location
+      despite ASLR — the natural feed into
+      :py:meth:`AbstractProcess.resolve_pointer_chain`.
+
+   .. py:attribute:: size
+      :type: int
+
+      Size of the module in memory, in bytes. ``0`` when the backend cannot
+      determine it. The meaning is **platform-specific**:
+
+      - **Windows** — full module image (``modBaseSize``).
+      - **Linux** — mapped span (covers ``.data`` / ``.bss``).
+      - **macOS** — ``__TEXT`` segment size; a single whole-module size is
+        ill-defined for dyld-shared-cache dylibs.
+
+   .. py:attribute:: raw
+      :type: Any
+
+      Underlying platform handle/key used to look up the module — the
+      ``MODULEENTRY32.hModule`` on Windows, the mapped path on Linux, the
+      Mach-O load address on macOS. Useful for advanced callers that need
+      to make follow-up OS-specific calls.
+```
+
+## Examples
+
+### Listing every module
+
+```python
+with OpenProcess(process_name="game.exe") as process:
+    for module in process.get_modules():
+        print(f"{module.name:32}  0x{module.base_address:016X}  {module.size:>12}")
+```
+
+### Finding the main executable
+
+```python
+main = next(m for m in process.get_modules() if m.name.endswith(".exe"))
+print(f"{main.name} loaded at 0x{main.base_address:X}")
+```
+
+### Using `base_address` as a pointer-chain root
+
+```python
+module = next(m for m in process.get_modules() if m.name == "game.exe")
+hp_addr = process.resolve_pointer_chain(
+    module.base_address + 0x10F4F4, [0x0, 0x158],
+)
+```
+
+```{seealso}
+- [Modules and threads guide](../guide/modules-threads.md)
+- [Pointers](../guide/pointers.md)
+```

--- a/docs/api/openprocess.md
+++ b/docs/api/openprocess.md
@@ -1,0 +1,227 @@
+# `OpenProcess` (process API)
+
+`OpenProcess` is the unified entry point. Depending on the host OS, it
+resolves to:
+
+<table>
+<tr><th>Platform</th><th>Concrete class</th></tr>
+<tr><td>🪟 Windows</td><td><code>PyMemoryEditor.win32.process.WindowsProcess</code></td></tr>
+<tr><td>🐧 Linux</td><td><code>PyMemoryEditor.linux.process.LinuxProcess</code></td></tr>
+<tr><td>🍎 macOS</td><td><code>PyMemoryEditor.macos.process.MacProcess</code></td></tr>
+</table>
+
+All three subclass `AbstractProcess` and share the API documented below.
+
+## Construction
+
+```{eval-rst}
+.. py:class:: OpenProcess(*, process_name=None, pid=None, permission=None, case_sensitive=None, exact_match=True)
+
+   Open a target process.
+
+   :param str process_name: name of the target process.
+   :param int pid: process ID. Takes precedence over ``process_name``.
+   :param permission: **Windows only.** A
+      :py:class:`ProcessOperationsEnum` value (or integer). Defaults to
+      read+write (``PROCESS_VM_READ | PROCESS_VM_WRITE | PROCESS_VM_OPERATION
+      | PROCESS_QUERY_INFORMATION``). On Linux and macOS this argument is
+      accepted for API parity but **ignored**; passing a non-``None`` value
+      emits ``UserWarning``.
+   :param bool case_sensitive: when ``False``, ``process_name`` matching
+      ignores case. Default is ``False`` on Windows, ``True`` elsewhere.
+   :param bool exact_match: when ``False``, ``process_name`` matches as a
+      substring (``"chrome"`` matches ``"chrome.exe"``).
+
+   :raises ProcessNotFoundError: no process matches ``process_name``.
+   :raises ProcessIDNotExistsError: ``pid`` doesn't exist.
+   :raises AmbiguousProcessNameError: more than one process matches.
+   :raises TypeError: neither ``process_name`` nor ``pid`` was provided.
+   :raises PermissionError: the OS denied access.
+```
+
+### Examples
+
+```python
+# By name
+with OpenProcess(process_name="game.exe") as process:
+    ...
+
+# By PID
+with OpenProcess(pid=1234) as process:
+    ...
+
+# Partial, case-insensitive name match (Windows-friendly)
+with OpenProcess(process_name="chrome", case_sensitive=False, exact_match=False) as process:
+    ...
+
+# Read-only handle (Windows only)
+from PyMemoryEditor import ProcessOperationsEnum
+
+with OpenProcess(
+    process_name="game.exe",
+    permission=ProcessOperationsEnum.PROCESS_VM_READ | ProcessOperationsEnum.PROCESS_QUERY_INFORMATION,
+) as process:
+    ...
+```
+
+## Attributes
+
+```{eval-rst}
+.. py:attribute:: pid
+   :type: int
+   :no-index:
+
+   The PID of the target process.
+
+.. py:attribute:: main_thread
+   :type: Optional[ThreadInfo]
+
+   The conventional "main thread" of the target — by convention, the thread
+   with the smallest ``tid``. Returns ``None`` if the process has no listable
+   threads (rare).
+```
+
+## Methods
+
+### Read / write
+
+```{eval-rst}
+.. py:method:: read_process_memory(address, pytype, bufflength=None)
+
+   Read a value from memory.
+
+   :param int address: target memory address.
+   :param Type pytype: ``bool``, ``int``, ``float``, ``str`` or ``bytes``.
+   :param int bufflength: value size in bytes (optional for numeric types).
+   :returns: the decoded value.
+
+.. py:method:: write_process_memory(address, pytype, bufflength, value)
+
+   Write a value to memory.
+
+   :param int address: target memory address.
+   :param Type pytype: one of the five supported types.
+   :param int bufflength: value size in bytes (``None`` for numeric defaults).
+   :param value: the value to write.
+   :returns: the written value.
+```
+
+### Searching
+
+```{eval-rst}
+.. py:method:: search_by_value(pytype, bufflength, value, scan_type=ScanTypesEnum.EXACT_VALUE, *, progress_information=False, writeable_only=False, memory_regions=None)
+
+   Yield every address holding ``value`` (compared per ``scan_type``).
+   See :doc:`../guide/searching` for a full walkthrough.
+
+.. py:method:: search_by_value_between(pytype, bufflength, start, end, *, not_between=False, progress_information=False, writeable_only=False, memory_regions=None)
+
+   Yield every address whose value is in ``[start, end]`` (or outside, with
+   ``not_between=True``).
+
+.. py:method:: search_by_addresses(pytype, bufflength, addresses, *, raise_error=False, memory_regions=None)
+
+   Read each address in ``addresses`` once, yielding ``(address, value)``.
+   Far faster than looping over :py:meth:`read_process_memory`.
+
+.. py:method:: search_by_pattern(pattern, *, byte_length=0, progress_information=False, memory_regions=None)
+
+   Scan memory for a byte pattern — IDA-style hex, raw bytes regex, or a
+   compiled :py:class:`re.Pattern`. See :doc:`../guide/pattern-scan`.
+```
+
+### Memory regions
+
+```{eval-rst}
+.. py:method:: get_memory_regions()
+
+   Yield a :py:class:`MemoryRegion` per region — an immutable dataclass with
+   ``address``, ``size``, ``is_readable``, ``is_writable``, ``is_executable``,
+   ``is_shared``, ``path`` and the platform-specific ``struct``.
+
+.. py:method:: snapshot_memory_regions()
+
+   Materialize the region list once as a :py:class:`MemoryRegionSnapshot`
+   (pre-sorted by base address), for reuse across iterative scans.
+```
+
+### Modules and threads
+
+```{eval-rst}
+.. py:method:: get_modules()
+
+   Yield a :py:class:`ModuleInfo` for every loaded module.
+
+.. py:method:: get_threads()
+
+   Yield a :py:class:`ThreadInfo` for every thread inside the target.
+```
+
+### Pointers
+
+```{eval-rst}
+.. py:method:: resolve_pointer_chain(base_address, offsets, *, ptr_size=8)
+
+   Walk a multi-level pointer chain and return the final address.
+
+.. py:method:: get_pointer(base_address, offsets=None, *, pytype=int, bufflength=None, ptr_size=8)
+
+   Build a :py:class:`RemotePointer` bound to this process — a live,
+   re-resolving handle. See :doc:`../guide/pointers`.
+
+.. py:method:: scan_pointer_paths(target_address, *, max_depth=5, max_offset=0x400, ptr_size=8, aligned=True, writable_only=True, static_ranges=None, max_results=None, memory_regions=None, progress_callback=None)
+
+   Reverse pointer scan — yield :py:class:`PointerPath` recipes that resolve
+   to ``target_address``. See :doc:`../guide/pointer-scan`.
+
+.. py:method:: save_pointer_paths(paths, file)
+
+   Save pointer paths to a JSON file.
+
+.. py:method:: load_pointer_paths(file)
+
+   Load pointer paths previously saved with :py:meth:`save_pointer_paths`.
+
+.. py:method:: rescan_pointer_paths(paths, target_address)
+
+   Keep only the paths that still resolve to ``target_address``.
+
+.. py:method:: compare_pointer_scans(*sources)
+
+   Intersect several saved scans — return the paths present in *every* one.
+```
+
+### Allocation
+
+```{eval-rst}
+.. py:method:: allocate_memory(size, *, permission=None)
+
+   Reserve ``size`` bytes inside the target. Windows and macOS only.
+
+.. py:method:: free_memory(address, size=0)
+
+   Release a previously allocated region.
+```
+
+### Lifecycle
+
+```{eval-rst}
+.. py:method:: close()
+
+   Close the process handle. Subsequent calls raise :py:class:`ClosedProcess`.
+
+.. py:method:: __enter__()
+.. py:method:: __exit__(exc_type, exc_value, exc_traceback)
+
+   The process is also a context manager — prefer the ``with`` block.
+```
+
+```{seealso}
+- [`ScanTypesEnum`](enums.md)
+- [`MemoryRegion`](memory-region.md)
+- [`RemotePointer`](remote-pointer.md)
+- [`PointerPath`](pointer-path.md)
+- [`ModuleInfo`](module-info.md)
+- [`ThreadInfo`](thread-info.md)
+- [Errors](errors.md)
+```

--- a/docs/api/pointer-path.md
+++ b/docs/api/pointer-path.md
@@ -1,0 +1,148 @@
+# `PointerPath`
+
+A discovered static pointer path, returned by `scan_pointer_paths`.
+
+```python
+from PyMemoryEditor import PointerPath
+```
+
+Resolving `base_address` and then walking `offsets` with
+`resolve_pointer_chain` lands on the target. When the base sits inside a
+known module, `module` / `module_offset` express it ASLR-independently so the
+path survives a restart — feed it to `rebase()` in the next run.
+
+## Construction
+
+```{eval-rst}
+.. py:class:: PointerPath(base_address, offsets, module=None, module_offset=None, ptr_size=8)
+
+   :param int base_address: absolute static base for *this* run (the slot
+      whose pointer the chain dereferences first).
+   :param Tuple[int, ...] offsets: forward-order offsets, ready to hand to
+      :py:meth:`resolve_pointer_chain`.
+   :param Optional[str] module: name of the module containing
+      ``base_address`` (``None`` when the base falls in a caller-supplied
+      static range with no known module).
+   :param Optional[int] module_offset: ``base_address - module.base_address``
+      — the portable, ASLR-independent part of the base. ``None`` when
+      ``module`` is.
+   :param int ptr_size: pointer width — ``8`` for 64-bit (default) or ``4``
+      for 32-bit.
+```
+
+`PointerPath` is a `@dataclass(frozen=True)` — instances are immutable and
+hashable.
+
+## Attributes
+
+<table>
+<tr><th>Attribute</th><th>Type</th><th>Meaning</th></tr>
+<tr><td><code>base_address</code></td><td><code>int</code></td><td>Absolute static base for the run the path was found in.</td></tr>
+<tr><td><code>offsets</code></td><td><code>Tuple[int, ...]</code></td><td>Forward-order offsets.</td></tr>
+<tr><td><code>module</code></td><td><code>Optional[str]</code></td><td>Module owning <code>base_address</code>.</td></tr>
+<tr><td><code>module_offset</code></td><td><code>Optional[int]</code></td><td><code>base_address - module.base_address</code>.</td></tr>
+<tr><td><code>ptr_size</code></td><td><code>int</code></td><td>Pointer width (4 or 8).</td></tr>
+</table>
+
+## Methods
+
+### Resolving
+
+```{eval-rst}
+.. py:method:: resolve(process)
+
+   Walk this path in ``process`` and return the final target address.
+
+   :param AbstractProcess process: the open process.
+   :returns: the target address (``int``).
+
+.. py:method:: to_pointer(process, *, pytype=int, bufflength=None)
+
+   Build a live :py:class:`RemotePointer` for the value at the end of this
+   path.
+
+   :returns: a :py:class:`RemotePointer` re-resolving on every access.
+```
+
+### Rebasing across runs
+
+```{eval-rst}
+.. py:method:: rebase(process)
+
+   Return a copy with ``base_address`` recomputed from the live module base
+   in ``process`` — the call that makes a saved path valid again after a
+   restart moved the module (ASLR).
+
+   :raises ValueError: this path has no associated module (its base came
+      from a caller-supplied static range), so it cannot be rebased.
+   :raises LookupError: the module is not loaded in ``process``.
+```
+
+### Serialization
+
+```{eval-rst}
+.. py:method:: to_dict()
+
+   Serialise to a JSON-friendly dict (hex strings) for export. The
+   ASLR-independent part — ``module`` + ``module_offset`` + ``offsets`` —
+   is what makes a saved path replayable in a later run via
+   :py:meth:`from_dict` + :py:meth:`rebase`.
+
+.. py:classmethod:: from_dict(data)
+
+   Rebuild a :py:class:`PointerPath` from :py:meth:`to_dict` output. Numeric
+   fields accept either hex strings (``"0x158"``) or plain ints.
+```
+
+### Comparison & display
+
+```{eval-rst}
+.. py:method:: recipe()
+
+   The ASLR-independent identity of this path:
+   ``(module, module_offset, offsets)``. Two paths from different runs
+   describe the *same* pointer when their recipes are equal.
+
+.. py:method:: __str__()
+
+   Cheat Engine-style textual representation, e.g.::
+
+      "game.exe"+0x10F4F4 -> [+0x0] -> +0x158
+```
+
+## Example workflows
+
+### Saving and reloading
+
+```python
+paths = list(process.scan_pointer_paths(address))
+process.save_pointer_paths(paths, "pointers.json")
+
+# Later, in a different run:
+loaded = process.load_pointer_paths("pointers.json")
+for path in loaded:
+    live = path.rebase(process)
+    print(live.resolve(process))
+```
+
+### Building a live handle from a saved path
+
+```python
+loaded = process.load_pointer_paths("pointers.json")
+hp_ptr = loaded[0].rebase(process).to_pointer(process, pytype=int, bufflength=4)
+hp_ptr.value = 9999
+```
+
+### Intersecting independent scans
+
+```python
+stable = process.compare_pointer_scans(
+    "scan1.json", "scan2.json", "scan3.json",
+)
+print(f"{len(stable)} stable pointers")
+```
+
+```{seealso}
+- [Pointer scan guide](../guide/pointer-scan.md)
+- [`RemotePointer`](remote-pointer.md)
+```

--- a/docs/api/remote-pointer.md
+++ b/docs/api/remote-pointer.md
@@ -1,0 +1,176 @@
+# `RemotePointer`
+
+A re-resolving, read/write handle to a typed value in a target process.
+
+```python
+from PyMemoryEditor import RemotePointer
+```
+
+Most users build a `RemotePointer` through `process.get_pointer(...)`. The
+constructor is documented here for completeness.
+
+## Construction
+
+```{eval-rst}
+.. py:class:: RemotePointer(process, base_address, offsets=None, *, pytype=int, bufflength=None, ptr_size=8)
+
+   :param AbstractProcess process: the open process the value lives in.
+   :param int base_address: starting address. For a direct handle this is the
+      address of the value itself; for a pointer chain it is typically
+      ``module_base + static_offset``.
+   :param offsets: how to reach the value from ``base_address``:
+
+      * ``None`` (default) — **direct handle**: ``address`` *is*
+        ``base_address``, with no dereferencing. Use this to wrap an address
+        you already have (e.g. from :py:meth:`search_by_value`).
+      * a sequence (including the empty list ``[]``) — the value sits at the
+        end of a pointer chain. ``address`` is recomputed on every access via
+        :py:meth:`resolve_pointer_chain`. ``[]`` dereferences ``base_address``
+        once; a non-empty list walks each offset, dereferencing all but the
+        last.
+
+   :param Type pytype: how to interpret the bytes — ``bool``, ``int``,
+      ``float``, ``str`` or ``bytes``. Defaults to ``int``.
+   :param int bufflength: value size in bytes. Optional for numeric types
+      (int→4, float→8, bool→1); required for ``str`` / ``bytes``.
+   :param int ptr_size: pointer width used when walking ``offsets`` — 8 for
+      64-bit targets (default), 4 for 32-bit. Ignored for direct handles.
+```
+
+## Properties
+
+```{eval-rst}
+.. py:attribute:: process
+   :type: AbstractProcess
+
+   The process this pointer reads from / writes to.
+
+.. py:attribute:: base_address
+   :type: int
+
+   The starting address the pointer was built with.
+
+.. py:attribute:: offsets
+   :type: Optional[Sequence[int]]
+
+   The pointer-chain offsets, or ``None`` for a direct handle.
+
+.. py:attribute:: address
+   :type: int
+
+   The address the value currently lives at. **Recomputed on every access**
+   for a pointer chain — so each read reflects where the target's pointers
+   point *now*.
+
+.. py:property:: value
+
+   Read or write the value at :py:attr:`address` using the bound type.
+
+      .. code-block:: python
+
+         hp_ptr.value           # read
+         hp_ptr.value = 9999    # write
+```
+
+## Methods
+
+```{eval-rst}
+.. py:method:: read(pytype=None, bufflength=None)
+
+   Read the value at :py:attr:`address`, optionally overriding the bound type
+   for one-off reads.
+
+   :param Type pytype: interpret the bytes as this type for this call only.
+   :param int bufflength: override the bound buffer size.
+   :returns: the decoded value.
+
+.. py:method:: write(value, pytype=None, bufflength=None)
+
+   Write ``value`` to :py:attr:`address`, optionally overriding the bound
+   type. Returns whatever :py:meth:`write_process_memory` returns.
+```
+
+## Operators
+
+`RemotePointer` supports C-style pointer arithmetic:
+
+```{eval-rst}
+.. py:method:: __add__(delta)
+.. py:method:: __radd__(delta)
+
+   ``ptr + n`` (or ``n + ptr``) → a **new** pointer ``n`` bytes ahead. Does
+   not touch memory.
+
+.. py:method:: __sub__(other)
+
+   - ``ptr - n`` → a new pointer ``n`` bytes behind.
+   - ``ptr - other`` (where ``other`` is a ``RemotePointer``) → the byte
+     distance between the two resolved addresses.
+
+.. py:method:: __int__()
+
+   The resolved :py:attr:`address`. Useful for arithmetic and logging:
+
+      .. code-block:: python
+
+         print(f"HP is at 0x{int(hp_ptr):X}")
+
+.. py:method:: __repr__()
+
+   Diagnostic representation, e.g.
+   ``<RemotePointer base=0x14010F4F4 -> [0, 344] pytype=int>``.
+```
+
+## Lazy chain folding
+
+When you do `hp_ptr + 4`, the shift is folded into the **last** offset of the
+chain (rather than the resolved address), so the returned pointer still
+re-walks the chain on every access. In other words, `(hp_ptr + 4)` keeps
+following the target as it moves around the heap — it doesn't snapshot the
+address at shift time.
+
+## Examples
+
+### Direct handle from a scan
+
+```python
+addresses = list(process.search_by_value(int, 4, 100))
+ptr = process.get_pointer(addresses[0], pytype=int, bufflength=4)
+
+ptr.value = 9999
+```
+
+### Chained handle from a cheat-table entry
+
+```python
+# "game.exe" + 0x10F4F4 -> [+0x0] -> [+0x158]
+module = next(m for m in process.get_modules() if m.name == "game.exe")
+hp = process.get_pointer(
+    module.base_address + 0x10F4F4,
+    [0x0, 0x158],
+    pytype=int,
+    bufflength=4,
+)
+hp.value -= 10
+```
+
+### Walking sibling fields with arithmetic
+
+```python
+# HP and MP are stored side-by-side as 4-byte ints.
+mp = hp + 4
+mp.value = 100
+```
+
+### Reading the same address as a different type
+
+```python
+# Peek the same address as raw bytes without building a second handle.
+print(hp.read(pytype=bytes, bufflength=4))
+```
+
+```{seealso}
+- [Pointers](../guide/pointers.md)
+- [Pointer scan](../guide/pointer-scan.md)
+- [`PointerPath`](pointer-path.md)
+```

--- a/docs/api/thread-info.md
+++ b/docs/api/thread-info.md
@@ -1,0 +1,95 @@
+# `ThreadInfo`
+
+A single thread inside a target process.
+
+```python
+from PyMemoryEditor import ThreadInfo
+```
+
+`ThreadInfo` is a `@dataclass(frozen=True)` returned by `process.get_threads()`.
+Each backend fills in the fields its OS surfaces cheaply; fields left `None`
+mean "this platform does not expose that attribute via the API we use".
+
+## Fields
+
+```{eval-rst}
+.. py:class:: ThreadInfo(tid, start_address=None, state=None, priority=None, raw=None)
+
+   .. py:attribute:: tid
+      :type: int
+
+      Thread identifier. **The meaning of `tid` is platform-specific:**
+
+      - **Linux** — POSIX TID. Same namespace as PID; ``gettid()`` returns
+        this.
+      - **Windows** — kernel-assigned global thread id (DWORD) from
+        ``THREADENTRY32``.
+      - **macOS** — Mach thread port name from ``task_threads``. Not the
+        BSD pthread id.
+
+   .. py:attribute:: start_address
+      :type: Optional[int]
+
+      Entry point of the thread, when the OS exposes it cheaply. ``None``
+      when not available.
+
+   .. py:attribute:: state
+      :type: Optional[str]
+
+      Short human-readable state — e.g. ``"R"`` / ``"S"`` on Linux. ``None``
+      when not available.
+
+   .. py:attribute:: priority
+      :type: Optional[int]
+
+      Scheduling priority value as reported by the OS. The scale is
+      platform-specific; ``None`` when not available.
+
+   .. py:attribute:: raw
+      :type: Any
+
+      Underlying platform handle/struct (``THREADENTRY32`` on Windows, the
+      TID string from ``/proc/<pid>/task/`` on Linux, a Mach port int on
+      macOS). Useful for advanced callers that need to make follow-up
+      OS-specific calls.
+```
+
+```{admonition} Don't mix tids across platforms
+:class: warning
+
+A `tid` returned on Linux is **not** comparable to a `tid` returned on
+Windows or macOS — they live in different namespaces. The same warning
+applies to mixing `tid` and `pid` values, which only share a namespace on
+Linux.
+```
+
+## Examples
+
+### Listing threads
+
+```python
+with OpenProcess(process_name="game.exe") as process:
+    for thread in process.get_threads():
+        print(thread.tid, thread.state, thread.priority)
+```
+
+### The main thread shortcut
+
+```python
+print("Main thread:", process.main_thread.tid)
+```
+
+`process.main_thread` returns the thread with the lowest `tid` — by
+convention the "main" thread. It returns `None` if the process has no
+listable threads (rare; usually means it just exited).
+
+### Counting workers
+
+```python
+threads = list(process.get_threads())
+print(f"{len(threads)} threads running")
+```
+
+```{seealso}
+- [Modules and threads guide](../guide/modules-threads.md)
+```

--- a/docs/api/utilities.md
+++ b/docs/api/utilities.md
@@ -1,0 +1,155 @@
+# Utilities
+
+A small set of helpers exposed under `PyMemoryEditor.util` for advanced
+callers that want to operate on bytes directly — convert between Python and
+ctypes types, compile AOB patterns without a live process, or chunk an
+arbitrary region for scanning.
+
+```python
+from PyMemoryEditor.util import (
+    resolve_bufflength,
+    convert_from_byte_array,
+    value_to_bytes,
+    values_to_bytes,
+    get_c_type_of,
+    compile_pattern,
+    iter_region_chunks,
+    scan_memory,
+    scan_memory_for_exact_value,
+    PatternLike,
+    DEFAULT_MAX_REGION_CHUNK,
+)
+```
+
+## Type conversion
+
+```{eval-rst}
+.. py:function:: resolve_bufflength(pytype, bufflength)
+
+   Return a concrete buffer length: the caller-provided value, or the default
+   for numeric ``pytype`` when ``bufflength`` is ``None``.
+
+   :raises ValueError: ``bufflength`` is required for ``pytype=str`` /
+      ``pytype=bytes``.
+
+.. py:function:: convert_from_byte_array(byte_array, pytype, length)
+
+   Convert a ctypes byte array to a Python value of type ``pytype``. String
+   decoding uses ``errors="replace"``.
+
+.. py:function:: value_to_bytes(pytype, bufflength, value)
+
+   Encode a single value as fixed-width bytes using the same ctypes
+   representation the backend compares against.
+
+.. py:function:: values_to_bytes(pytype, bufflength, value)
+
+   Convert either a single value or a tuple of values (for
+   ``VALUE_BETWEEN`` / ``NOT_VALUE_BETWEEN``) to the corresponding byte form.
+
+.. py:function:: get_c_type_of(pytype, length)
+
+   Return the underlying ctypes object for the given Python type and width.
+```
+
+## Pattern compilation
+
+```{eval-rst}
+.. py:function:: compile_pattern(pattern, *, byte_length=0)
+
+   Compile ``pattern`` into a ``(re.Pattern[bytes], byte_length)`` pair.
+
+   :param pattern: an IDA-style hex string, a raw bytes regex, or a compiled
+      ``re.Pattern[bytes]``.
+   :param int byte_length: required for regex / compiled patterns — the
+      number of bytes one match consumes.
+   :raises ValueError: malformed IDA-style token, or ``byte_length`` omitted
+      for a regex / pre-compiled pattern.
+```
+
+### Example
+
+```python
+from PyMemoryEditor.util import compile_pattern
+
+regex, byte_length = compile_pattern("48 8B ? 00 00")
+print(regex.pattern)   # b'\\x48\\x8B.\\x00\\x00'
+print(byte_length)     # 5
+```
+
+```{eval-rst}
+.. py:data:: PatternLike
+
+   Type alias: ``Union[str, bytes, re.Pattern[bytes]]``. The set of input
+   forms ``compile_pattern`` accepts.
+```
+
+## Region chunking
+
+```{eval-rst}
+.. py:data:: DEFAULT_MAX_REGION_CHUNK
+
+   Maximum chunk size used by :py:func:`iter_region_chunks` (currently
+   16 MiB). Tunes the trade-off between syscall overhead (small chunks) and
+   peak memory use (huge chunks).
+
+.. py:function:: iter_region_chunks(region_size, item_size)
+
+   Yield ``(offset, chunk_size)`` pairs that walk a single memory region in
+   bounded-size chunks. The chunks slightly **overlap** so a pattern straddling
+   a boundary is still emitted by the higher-level scanner.
+
+.. py:function:: scan_memory(...)
+.. py:function:: scan_memory_for_exact_value(...)
+
+   Low-level scan kernels used by the backends. Public for advanced use only —
+   the high-level :py:meth:`search_by_value` / :py:meth:`search_by_pattern`
+   methods are the recommended API.
+```
+
+## Region predicates
+
+The helpers in `PyMemoryEditor.process.region` operate on a **raw platform
+struct** — the same ``struct`` field carried by a
+[`MemoryRegion`](memory-region.md). Useful when you've obtained a platform
+descriptor outside the normal flow and want to compute the portable booleans
+yourself.
+
+```python
+from PyMemoryEditor.process.region import (
+    is_region_readable,
+    is_region_writable,
+    is_region_executable,
+    is_region_shared,
+    region_path,
+    make_region,
+)
+```
+
+```{eval-rst}
+.. py:function:: is_region_readable(struct)
+.. py:function:: is_region_writable(struct)
+.. py:function:: is_region_executable(struct)
+.. py:function:: is_region_shared(struct)
+
+   True/False from a platform descriptor (``MEMORY_BASIC_INFORMATION`` on
+   Windows/Linux; the VM struct on macOS). For a fully-populated region,
+   prefer the boolean attributes on :py:class:`MemoryRegion`
+   (``region.is_readable``, etc.).
+
+.. py:function:: region_path(struct)
+
+   Best-effort path of the file backing the region, or ``""`` when unknown
+   (Linux only — Windows/macOS would need extra syscalls).
+
+.. py:function:: make_region(address, size, struct)
+
+   Build a fully-populated :py:class:`MemoryRegion` from a platform struct.
+   The four boolean fields and ``path`` are computed once via the predicates
+   above. Backends call this once per region; user code rarely needs it.
+```
+
+```{seealso}
+- [Memory regions](../guide/memory-regions.md)
+- [Pattern scan](../guide/pattern-scan.md)
+```

--- a/docs/app.md
+++ b/docs/app.md
@@ -1,0 +1,133 @@
+# The PyMemoryEditor GUI App
+
+PyMemoryEditor ships with a **polished cross-platform GUI** built on
+**PySide6 (Qt for Python)**. It's a Cheat Engine-inspired memory scanner that
+exercises every public surface of the library — so it doubles as a living
+demo and a teaching tool.
+
+If you're new to memory editing, **start with the app** before writing code.
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/JeanExtreme002/PyMemoryEditor/main/assets/screenshots/app.png" alt="PyMemoryEditor app attached to a running process" width="820" />
+</p>
+
+## Install
+
+```bash
+pip install "PyMemoryEditor[app]"
+```
+
+The `app` extra adds PySide6 to the install. The library itself stays
+dependency-free.
+
+## Launch
+
+From any terminal:
+
+```bash
+pymemoryeditor
+```
+
+The app opens with the **Open Process** dialog, where you pick a target by
+name or PID.
+
+## What's inside
+
+<table>
+<tr>
+<td width="50%" valign="top">
+
+### 🎯 Scanner
+
+- Every `ScanTypesEnum` mode
+- All five value types (`int`, `float`, `bool`, `str`, `bytes`)
+- Range search
+- AOB / byte signature search
+- Regex search
+
+### 🔁 Refine workflow
+
+- **First Scan → Next Scan** (Cheat Engine style)
+- Eight Next Scan comparisons (increased, decreased, changed, unchanged, …)
+- Live progress
+
+### 📋 Cheat table
+
+- Freeze / write values continuously
+- Per-entry custom labels
+- JSON import/export
+
+</td>
+<td width="50%" valign="top">
+
+### 🔗 Pointer scan
+
+- Same engine as `scan_pointer_paths`
+- Save scans to JSON
+- Rescan / compare scans to narrow them down
+- Build live `RemotePointer` from a result
+
+### 🗺️ Memory map
+
+- All regions with R/W/X flags
+- Source file / module per region (where available)
+
+### 🔬 Hex viewer
+
+- Live dump with write-back
+- Address goto, navigation
+
+### 🪵 Log console
+
+- Same stream as `logging.getLogger("PyMemoryEditor")`
+- Toggle DEBUG verbosity at runtime
+
+</td>
+</tr>
+</table>
+
+```{admonition} Cross-platform dark theme
+:class: tip
+
+The app ships with a dark theme that follows the system on macOS and Windows
+11 and uses a manual toggle elsewhere. Themes live under
+**View → Theme**.
+```
+
+## Typical workflow
+
+1. **Open a process** from the dialog (or `File → Open Process`).
+2. **Run a First Scan**: pick the value type, type the value you can see, hit
+   *First Scan*.
+3. **Refine** with Next Scan after the value changes — pick *Exact Value* with
+   the new number, or one of the *increased / decreased / changed* shortcuts.
+4. When the list is small, **double-click** a result to add it to the
+   **Cheat Table**.
+5. **Freeze** the value with the checkbox or change it from the Cheat Table.
+6. (Optional) **Run a Pointer Scan** on the result to find a chain that
+   survives restarts.
+
+## Importing & exporting
+
+The Cheat Table and Pointer Scan results are stored as plain **JSON**, so you
+can:
+
+- Share a cheat table with a friend.
+- Version-control your saved pointer scans.
+- Diff scans by hand.
+
+The pointer-scan format is documented in [`PointerPath`](api/pointer-path.md).
+
+## When to use the app vs the library
+
+<table>
+<tr><th>Use the GUI when…</th><th>Use the library when…</th></tr>
+<tr><td>You're exploring a target interactively.</td><td>You want to script a workflow or build a tool.</td></tr>
+<tr><td>You're learning memory editing.</td><td>You want to embed memory access into a bigger application.</td></tr>
+<tr><td>You want to inspect what's available before writing code.</td><td>You need batch processing, automation, or CI integration.</td></tr>
+</table>
+
+```{seealso}
+- [Quick Start](quickstart.md) — the same workflow, in code.
+- [Logging](guide/logging.md) — the Log Console exposes the library's logger.
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+"""Sphinx configuration for PyMemoryEditor's documentation.
+
+The docs use the MyST parser so every page can be written in Markdown, with
+optional reStructuredText directives where they help (e.g. ``{toctree}``,
+admonitions). The Furo theme provides a modern dark/light HTML build.
+"""
+
+import os
+import sys
+from datetime import datetime
+
+# Make the package importable for autodoc-style cross references.
+sys.path.insert(0, os.path.abspath(".."))
+
+# -- Project information -----------------------------------------------------
+
+project = "PyMemoryEditor"
+author = "Jean Loui Bernard Silva de Jesus"
+copyright = f"{datetime.now().year}, {author}"
+
+try:
+    from PyMemoryEditor import __version__ as release
+except Exception:  # pragma: no cover - docs can build without the package installed
+    release = "2.0.0"
+
+version = ".".join(release.split(".")[:2])
+
+# -- General configuration ---------------------------------------------------
+
+extensions = [
+    "myst_parser",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
+    "sphinx_copybutton",
+    "sphinx_design",
+]
+
+source_suffix = {
+    ".md": "markdown",
+    ".rst": "restructuredtext",
+}
+
+master_doc = "index"
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# -- MyST configuration ------------------------------------------------------
+
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+    "fieldlist",
+    "html_image",
+    "html_admonition",
+    "linkify",
+    "replacements",
+    "smartquotes",
+    "substitution",
+    "tasklist",
+]
+
+myst_heading_anchors = 3
+
+# -- HTML output -------------------------------------------------------------
+
+html_theme = "furo"
+html_title = "PyMemoryEditor"
+
+html_theme_options = {
+    "sidebar_hide_name": False,
+    "navigation_with_keys": True,
+    "source_repository": "https://github.com/JeanExtreme002/PyMemoryEditor/",
+    "source_branch": "main",
+    "source_directory": "docs/",
+    "light_css_variables": {
+        "color-brand-primary": "#8A2BE2",
+        "color-brand-content": "#8A2BE2",
+    },
+    "dark_css_variables": {
+        "color-brand-primary": "#B57AFF",
+        "color-brand-content": "#B57AFF",
+    },
+}
+
+html_static_path = ["_static"]
+
+# Logo and favicon resolved from the bundled SVG icon.
+html_logo = "../PyMemoryEditor/app/assets/icon.svg"
+html_favicon = "../PyMemoryEditor/app/assets/icon.svg"
+
+# -- Intersphinx mappings ----------------------------------------------------
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+}
+
+# -- Autodoc -----------------------------------------------------------------
+
+autodoc_default_options = {
+    "members": True,
+    "undoc-members": False,
+    "show-inheritance": True,
+}
+autodoc_member_order = "bysource"
+autoclass_content = "both"
+
+# -- copybutton --------------------------------------------------------------
+
+copybutton_prompt_text = r">>> |\.\.\. |\$ "
+copybutton_prompt_is_regexp = True

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,99 @@
+# Glossary
+
+A short reference of the terms used throughout this documentation.
+
+```{glossary}
+
+Address
+   A numeric position in a process's virtual memory. PyMemoryEditor uses
+   Python ``int``s for addresses and prints them as hex (``0x14010F4F4``).
+
+ASLR
+   *Address Space Layout Randomization* — a kernel feature that loads modules
+   (and randomizes some allocations) at different base addresses each run.
+   It is the reason a scanned address is "gone" on the next launch, and the
+   reason {term}`pointer scans <Pointer scan>` exist.
+
+AOB
+   *Array Of Bytes* — a byte signature used to locate code or data by its
+   shape. PyMemoryEditor accepts IDA-style strings (``"48 8B ? ? 00"``) as
+   well as raw bytes regex patterns. See [Pattern scan](guide/pattern-scan.md).
+
+Base address
+   The address at which a {term}`module` is loaded for the current run.
+   Combine it with a static offset (``module.base_address + 0x10F4F4``) to
+   reach a known location despite {term}`ASLR`.
+
+Cheat table
+   A list of saved addresses (and the values to write to them). The bundled
+   GUI app stores cheat tables as JSON.
+
+ctypes
+   The [Python stdlib module](https://docs.python.org/3/library/ctypes.html)
+   used by PyMemoryEditor to call OS APIs without a native build step.
+
+Direct handle
+   A {term}`RemotePointer` whose ``offsets`` is ``None`` — its resolved
+   address is just the ``base_address``, with no dereferencing. The result
+   of wrapping a freshly-scanned address.
+
+Memory region
+   A contiguous block of virtual memory in a process, with a single set of
+   permissions (R/W/X/shared). ``get_memory_regions()`` enumerates them.
+
+Module
+   A file mapped into a process — the main executable plus every shared
+   library it loaded. PyMemoryEditor surfaces them as
+   :py:class:`ModuleInfo`.
+
+Pointer chain
+   A static base plus a series of offsets:
+   ``module + offset → [+x] → [+y] → ... → +n``. Walking the chain lands on a
+   value's current address — useful because the value typically lives at
+   a different absolute address every run.
+
+Pointer scan
+   The reverse of walking a chain: given a value's *current* address, find
+   the chains (recipes) that resolve to it. See
+   [Pointer scan](guide/pointer-scan.md).
+
+Process
+   An OS-level running program. PyMemoryEditor identifies a process by name
+   or PID.
+
+PID
+   *Process Identifier* — the OS-assigned integer that uniquely names a
+   running process at a point in time.
+
+ptrace_scope
+   The Linux kernel's policy for which non-child processes can be attached
+   to. See [Platform Notes → Linux](project:#linux).
+
+Refine scan
+   An iterative scan: an initial scan returns many candidates, the value
+   changes in the target, and the candidate list is narrowed to only those
+   that still match. The classic Cheat Engine workflow.
+
+RemotePointer
+   A live, re-resolving handle to a typed value in another process. Reading
+   ``.value`` walks any associated chain again, so the handle keeps working
+   as the target moves things around in memory.
+
+Scan
+   To search the memory of a process for an address matching some criterion
+   — a value, a range, or a byte pattern.
+
+SIP
+   *System Integrity Protection* — macOS's kernel-level protection that
+   prevents most processes from being inspected. Affects how PyMemoryEditor
+   attaches to processes on macOS.
+
+Static base
+   An address that is **fixed at a known offset from a module's base** —
+   the kind of address a pointer chain can start from and still work after
+   a restart.
+
+TID
+   *Thread Identifier* — the OS-assigned integer naming a thread. The
+   meaning varies per OS (see [`ThreadInfo`](api/thread-info.md)).
+```

--- a/docs/guide/allocate-free.md
+++ b/docs/guide/allocate-free.md
@@ -1,0 +1,171 @@
+# Allocating and freeing memory
+
+PyMemoryEditor can **reserve** new memory inside the target process and
+**release** it later. This is useful for storing custom data the target
+program will read, or for staging code injection scenarios.
+
+## Allocating
+
+`allocate_memory(size)` reserves a new region in the target's address space
+and returns its base address. The OS may round the size up to the page
+size:
+
+```python
+with OpenProcess(process_name="game.exe") as process:
+    address = process.allocate_memory(64)
+    process.write_process_memory(address, int, 4, 1337)
+```
+
+## Freeing
+
+`free_memory(address)` releases the region. The library remembers each
+allocation's size, so you don't have to:
+
+```python
+process.free_memory(address)
+```
+
+Pass an explicit `size=` only when freeing a region that this object **did not
+allocate** (e.g. one inherited from another script):
+
+```python
+process.free_memory(address, size=4096)
+```
+
+## Method signatures
+
+```{eval-rst}
+.. py:method:: allocate_memory(size, *, permission=None)
+   :no-index:
+
+   Reserve and commit ``size`` bytes inside the target process's address space
+   and return the base address of the new region.
+
+   :param int size: number of bytes to allocate (rounded up to the OS page
+      size by the kernel).
+   :param permission: optional, **platform-specific** protection for the new
+      region — see the platform table below.
+   :returns: the base address of the new region.
+   :raises NotImplementedError: on Linux (see below).
+
+.. py:method:: free_memory(address, size=0)
+   :no-index:
+
+   Release a region previously returned by :py:meth:`allocate_memory`.
+
+   :param int address: base address returned by :py:meth:`allocate_memory`.
+   :param int size: size of the region in bytes. May be left ``0`` to reuse
+      the size recorded when the region was allocated (required on macOS,
+      ignored on Windows where ``MEM_RELEASE`` frees the whole allocation).
+      Pass an explicit size only to free a region this object did not
+      allocate.
+   :returns: ``True`` on success.
+   :raises NotImplementedError: on Linux.
+```
+
+## Platform behavior
+
+<table>
+<tr>
+<th>Platform</th>
+<th>Status</th>
+<th>Default <code>permission</code></th>
+<th>Underlying API</th>
+</tr>
+<tr>
+<td>🪟 <b>Windows</b></td>
+<td>✅ Supported</td>
+<td><code>PAGE_EXECUTE_READWRITE</code> (executable + writable)</td>
+<td><code>VirtualAllocEx</code> / <code>VirtualFreeEx</code></td>
+</tr>
+<tr>
+<td>🍎 <b>macOS</b></td>
+<td>✅ Supported</td>
+<td>Mach default (read+write)</td>
+<td><code>mach_vm_allocate</code> / <code>mach_vm_deallocate</code></td>
+</tr>
+<tr>
+<td>🐧 <b>Linux</b></td>
+<td>❌ <b>Not supported</b></td>
+<td>—</td>
+<td>Raises <code>NotImplementedError</code></td>
+</tr>
+</table>
+
+```{admonition} Why no Linux?
+:class: warning
+
+Linux has no syscall to allocate memory in another process's address space —
+`mmap` only affects the calling process. Cross-process allocation would
+require a **ptrace-based engine** to make the target call `mmap` itself.
+PyMemoryEditor doesn't ship one. Calling `allocate_memory` or `free_memory`
+on Linux raises `NotImplementedError`.
+```
+
+## Choosing a permission
+
+The `permission=` argument mirrors `OpenProcess(permission=...)`.
+
+### On Windows
+
+Pass a `MemoryProtectionsEnum` (or the underlying integer):
+
+```python
+from PyMemoryEditor import OpenProcess
+from PyMemoryEditor.win32.enums.memory_protections import MemoryProtectionsEnum
+
+with OpenProcess(process_name="game.exe") as process:
+    # Allocate a read-only buffer.
+    address = process.allocate_memory(64, permission=MemoryProtectionsEnum.PAGE_READONLY)
+```
+
+Common values:
+
+<table>
+<tr><th>Value</th><th>Meaning</th></tr>
+<tr><td><code>PAGE_NOACCESS</code></td><td>No access at all.</td></tr>
+<tr><td><code>PAGE_READONLY</code></td><td>Read-only.</td></tr>
+<tr><td><code>PAGE_READWRITE</code></td><td>Read + write.</td></tr>
+<tr><td><code>PAGE_EXECUTE_READ</code></td><td>Read + execute.</td></tr>
+<tr><td><code>PAGE_EXECUTE_READWRITE</code> <em>(default)</em></td><td>Read + write + execute.</td></tr>
+</table>
+
+### On macOS
+
+Pass a `VM_PROT_*` bitmask (or leave `None` for the default of read+write):
+
+```python
+# read+write+execute (may fail under the hardened runtime).
+process.allocate_memory(4096, permission=VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXECUTE)
+```
+
+```{admonition} Hardened runtime on Apple Silicon
+:class: note
+
+Requesting **executable** allocations may fail on macOS, especially on Apple
+Silicon under the hardened runtime. Stick to read+write if you don't need to
+execute injected code.
+```
+
+## A complete example
+
+```python
+from PyMemoryEditor import OpenProcess
+
+with OpenProcess(process_name="game.exe") as process:
+    address = process.allocate_memory(128)
+    try:
+        # Write something to it
+        process.write_process_memory(address, str, 128, "Hello from PyMemoryEditor!")
+
+        # Read it back
+        msg = process.read_process_memory(address, str, 128)
+        print(msg.split("\x00", 1)[0])
+    finally:
+        process.free_memory(address)
+```
+
+```{seealso}
+- [Reading and writing memory](read-write.md)
+- [Platform Notes](../platform-notes.md)
+```

--- a/docs/guide/logging.md
+++ b/docs/guide/logging.md
@@ -1,0 +1,78 @@
+# Logging and diagnostics
+
+PyMemoryEditor uses the standard `logging` module to emit informational
+messages from inside its scans. By default, the library is **silent** — a
+`NullHandler` is attached so nothing is printed unless you opt in.
+
+## Turning logging on
+
+To see what the library is doing internally, attach a handler to the
+`PyMemoryEditor` logger:
+
+```python
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+logging.getLogger("PyMemoryEditor").setLevel(logging.DEBUG)
+```
+
+You'll start seeing messages like:
+
+```
+DEBUG    PyMemoryEditor: skipping region 0x7FFD0000–0x7FFD2000 (read failed)
+WARNING  PyMemoryEditor: partial read at 0x14010F4F4 (got 6 of 8 bytes)
+```
+
+## Log levels
+
+<table>
+<tr><th>Level</th><th>When it fires</th></tr>
+<tr><td><code>DEBUG</code></td><td>Transient skips (pages vanished mid-scan, unreadable chunks).</td></tr>
+<tr><td><code>WARNING</code></td><td>Surprising-but-recovered conditions (partial reads, <code>mach_vm_protect</code> restore failure on macOS).</td></tr>
+</table>
+
+## Routing logs
+
+You can route the logger anywhere you like — to a file, to a Qt widget, to a
+remote log collector:
+
+```python
+import logging
+
+logger = logging.getLogger("PyMemoryEditor")
+handler = logging.FileHandler("memscan.log")
+handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+logger.addHandler(handler)
+logger.setLevel(logging.DEBUG)
+```
+
+## The bundled GUI app
+
+The GUI app exposes the same log stream in its **Log Console**:
+
+<table>
+<tr><td><b>Menu</b></td><td>Tools → Log Console</td></tr>
+</table>
+
+Toggling DEBUG verbosity in the console reveals the same messages the library
+sends to the Python logger.
+
+## macOS write-side-effect warning
+
+On macOS, writing to a read-only page transparently elevates the page
+protection, performs the write, and tries to restore the original
+protection. If the restore step fails, the library emits a `ResourceWarning`
+and the target page is left more permissive than it started.
+
+```python
+import warnings
+
+# Treat the warning as an error so you don't miss it.
+warnings.filterwarnings("error", category=ResourceWarning)
+```
+
+See [Platform Notes → macOS](project:#macos) for the details.
+
+```{seealso}
+- [Troubleshooting](../troubleshooting.md) — common errors and how to fix them.
+```

--- a/docs/guide/memory-regions.md
+++ b/docs/guide/memory-regions.md
@@ -1,0 +1,133 @@
+# Memory regions
+
+A process's address space is split into **regions** — contiguous blocks of
+memory, each with its own size, permissions and origin. Understanding the
+region map is the foundation of memory editing: every read, write or scan
+ultimately touches a region.
+
+## Listing the regions
+
+`get_memory_regions()` is a generator that yields one
+[`MemoryRegion`](../api/memory-region.md) per region:
+
+```python
+with OpenProcess(process_name="game.exe") as process:
+    for region in process.get_memory_regions():
+        print(
+            hex(region.address),
+            region.size,
+            "R" if region.is_readable else "-",
+            "W" if region.is_writable else "-",
+            "X" if region.is_executable else "-",
+            "shared" if region.is_shared else "",
+        )
+```
+
+## The `MemoryRegion` dataclass
+
+Each region is an instance of `MemoryRegion` — an immutable
+`@dataclass(frozen=True)` with the following fields:
+
+<table>
+<tr><th>Field</th><th>Type</th><th>Meaning</th></tr>
+<tr><td><code>address</code></td><td><code>int</code></td><td>Base address of the region.</td></tr>
+<tr><td><code>size</code></td><td><code>int</code></td><td>Region size in bytes.</td></tr>
+<tr><td><code>is_readable</code></td><td><code>bool</code></td><td>True if the region can be read.</td></tr>
+<tr><td><code>is_writable</code></td><td><code>bool</code></td><td>True if the region can be written.</td></tr>
+<tr><td><code>is_executable</code></td><td><code>bool</code></td><td>True if the region contains executable code.</td></tr>
+<tr><td><code>is_shared</code></td><td><code>bool</code></td><td>True if the region is a shared/file-backed mapping.</td></tr>
+<tr><td><code>path</code></td><td><code>str</code></td><td>File backing the region (Linux only — empty on Windows/macOS).</td></tr>
+<tr><td><code>struct</code></td><td>platform-specific</td><td>Raw platform descriptor (see below).</td></tr>
+</table>
+
+```{admonition} Immutability
+:class: tip
+
+`MemoryRegion` is frozen, so any region you obtain from
+`get_memory_regions()` or `snapshot_memory_regions()` is safe to share across
+threads or pass through functions without defensive copies.
+```
+
+### The platform-specific `struct`
+
+The `struct` attribute carries the underlying OS-specific descriptor. You
+usually won't need it — the portable booleans above are enough. When you do:
+
+- **Windows** — `MEMORY_BASIC_INFORMATION_{32,64}` with `Protect` (PAGE_* bitmask)
+  and `Type` (`MEM_PRIVATE` / `MEM_IMAGE` / `MEM_MAPPED`).
+- **Linux** — a small struct with `Privileges` (bytes like `rwxp` / `rwxs`).
+- **macOS** — a struct with `Protection` (`VM_PROT_*` bitmask) and `Shared`.
+
+## Snapshotting for refine workflows
+
+For iterative scans (the Cheat Engine "First Scan → Next Scan" loop),
+`snapshot_memory_regions()` materializes the region list once so subsequent
+calls can reuse it:
+
+```python
+regions = process.snapshot_memory_regions()
+
+# Pass the same snapshot to as many scans as you want.
+candidates = list(process.search_by_value(int, 4, 100, memory_regions=regions))
+refined = list(process.search_by_addresses(int, 4, candidates, memory_regions=regions))
+```
+
+The return type is `MemoryRegionSnapshot` — a thin `list` subclass that
+behaves exactly like `list[MemoryRegion]`. Internally, the scan helpers
+detect via `isinstance(memory_regions, MemoryRegionSnapshot)` that the list
+is already address-sorted and skip the per-call `sorted(...)` step.
+
+```{admonition} Filtered snapshots are not pre-sorted anymore
+:class: note
+
+When you build a new list from a snapshot (`[r for r in snap if r.is_writable]`),
+the result is a plain `list`, not a `MemoryRegionSnapshot`. The scan helpers
+will re-sort it defensively — safe but slightly slower for huge region maps.
+Pass the original snapshot when you can.
+```
+
+See [Searching memory](searching.md#the-refine-scan-workflow) for the full
+recipe.
+
+## Filtering regions yourself
+
+Once you have the snapshot, you can filter it however you like before handing
+it to a scan:
+
+```python
+# Only writable regions (skip read-only static data — much faster).
+writable = [r for r in regions if r.is_writable]
+
+for address in process.search_by_value(int, 4, target, memory_regions=writable):
+    ...
+```
+
+## A complete region map
+
+A small script that prints a textual memory map (similar to the GUI app's
+Memory Map dialog):
+
+```python
+from PyMemoryEditor import OpenProcess
+
+with OpenProcess(process_name="game.exe") as process:
+    print(f"{'ADDRESS':<18}{'SIZE':>14}  RWX  Source")
+
+    for region in process.get_memory_regions():
+        rwx = "".join([
+            "R" if region.is_readable else "-",
+            "W" if region.is_writable else "-",
+            "X" if region.is_executable else "-",
+        ])
+        print(
+            f"0x{region.address:016X}  "
+            f"{region.size:>12,}  {rwx}  "
+            f"{region.path or ''}"
+        )
+```
+
+```{seealso}
+- [API → `MemoryRegion`](../api/memory-region.md)
+- [Modules & threads](modules-threads.md) — list loaded DLLs/SOs/dylibs and threads.
+- [Searching memory](searching.md) — the high-level scan API.
+```

--- a/docs/guide/modules-threads.md
+++ b/docs/guide/modules-threads.md
@@ -1,0 +1,170 @@
+# Modules and threads
+
+Beyond memory regions, PyMemoryEditor exposes two more inspection APIs:
+
+- **`get_modules()`** — every executable and shared library loaded into the
+  process.
+- **`get_threads()`** — every thread currently running inside the process.
+
+Both return immutable dataclass instances and are cross-platform.
+
+## Loaded modules
+
+A *module* is a file mapped into the process — the main executable plus every
+shared library it loaded (`.exe`/`.dll` on Windows, the binary and `.so` files
+on Linux, the Mach-O image and `.dylib` files on macOS).
+
+```python
+with OpenProcess(process_name="game.exe") as process:
+    for module in process.get_modules():
+        print(
+            module.name,
+            hex(module.base_address),
+            module.size,
+            module.path,
+        )
+```
+
+### The `ModuleInfo` dataclass
+
+```{eval-rst}
+.. py:class:: ModuleInfo
+   :no-index:
+
+   .. py:attribute:: name
+      :no-index:
+      :type: str
+
+      File name of the module — e.g. ``"game.exe"``, ``"libc.so.6"``.
+
+   .. py:attribute:: path
+      :no-index:
+      :type: str
+
+      Full path of the backing file on disk when the OS exposes it; falls back
+      to ``name`` when only the name is available.
+
+   .. py:attribute:: base_address
+      :no-index:
+      :type: int
+
+      Address where the module is loaded **for this run**. Combine it with a
+      static offset (``base_address + offset``) to reach a known location
+      despite ASLR — the natural feed into
+      :py:meth:`AbstractProcess.resolve_pointer_chain`.
+
+   .. py:attribute:: size
+      :no-index:
+      :type: int
+
+      Module size in bytes. ``0`` when the backend cannot determine it.
+      Platform-specific: full image on Windows/Linux; ``__TEXT`` segment size
+      on macOS.
+
+   .. py:attribute:: raw
+      :no-index:
+      :type: Any
+
+      Underlying platform handle for advanced follow-up calls.
+```
+
+### Finding a module by name
+
+```python
+def find_module(process, name):
+    for module in process.get_modules():
+        if module.name == name:
+            return module
+    return None
+
+with OpenProcess(pid=1234) as process:
+    main_module = find_module(process, "game.exe")
+    if main_module:
+        # Use module.base_address + static_offset as the base of a pointer chain.
+        hp_addr = process.resolve_pointer_chain(
+            main_module.base_address + 0x10F4F4, [0x0, 0x158],
+        )
+```
+
+## Threads
+
+`get_threads()` yields a `ThreadInfo` for every thread running inside the
+target. It's useful for introspection ("how many workers does it spawn?",
+"is the main thread still alive?").
+
+```python
+with OpenProcess(process_name="game.exe") as process:
+    for thread in process.get_threads():
+        print(thread.tid, thread.state, thread.priority)
+
+    print("Main thread:", process.main_thread.tid)
+```
+
+### The `ThreadInfo` dataclass
+
+```{eval-rst}
+.. py:class:: ThreadInfo
+   :no-index:
+
+   .. py:attribute:: tid
+      :no-index:
+      :type: int
+
+      Thread identifier. **The meaning is platform-specific**:
+
+      - **Linux** — POSIX TID; same namespace as PID.
+      - **Windows** — kernel-assigned DWORD thread id.
+      - **macOS** — Mach thread port name.
+
+   .. py:attribute:: start_address
+      :no-index:
+      :type: Optional[int]
+
+      Thread entry point when the OS exposes it cheaply; ``None`` otherwise.
+
+   .. py:attribute:: state
+      :no-index:
+      :type: Optional[str]
+
+      Short human-readable state (e.g. ``"R"``/``"S"`` on Linux). ``None`` on
+      platforms that don't surface it.
+
+   .. py:attribute:: priority
+      :no-index:
+      :type: Optional[int]
+
+      Scheduling priority as reported by the OS. Scale is platform-specific;
+      ``None`` when not exposed.
+
+   .. py:attribute:: raw
+      :no-index:
+      :type: Any
+
+      Underlying platform handle (``THREADENTRY32`` on Windows, the TID path on
+      Linux, a Mach port int on macOS). Useful for advanced follow-up calls.
+```
+
+### The `main_thread` shortcut
+
+The `process.main_thread` property is a convenience for the conventional "main
+thread" — by convention, the thread with the smallest `tid`:
+
+```python
+print(process.main_thread.tid)
+```
+
+It returns `None` if the target has no listable threads (rare; typically means
+the process just exited).
+
+```{admonition} Cross-platform tid semantics
+:class: warning
+
+Don't mix `tid`s with `pid`s, and don't compare `tid`s across operating
+systems. On Linux a TID and a PID share a namespace; on Windows and macOS they
+don't.
+```
+
+```{seealso}
+- [Memory regions](memory-regions.md) — list the process's address space.
+- [Pointers](pointers.md) — use `module.base_address + offset` as a static base.
+```

--- a/docs/guide/opening-process.md
+++ b/docs/guide/opening-process.md
@@ -1,0 +1,154 @@
+# Opening a process
+
+Everything starts with `OpenProcess` — the unified entry point for all three
+operating systems. Under the hood it returns the right backend
+(`WindowsProcess`, `LinuxProcess` or `MacProcess`), but you never have to care:
+the API is identical.
+
+## Basic usage
+
+```python
+from PyMemoryEditor import OpenProcess
+
+with OpenProcess(process_name="notepad.exe") as process:
+    print("PID:", process.pid)
+```
+
+The `with` block automatically calls `process.close()` when you leave it,
+releasing any OS handle the backend acquired.
+
+## Identify the process — by name or PID
+
+You can identify the target in two ways:
+
+<table>
+<tr>
+<th width="40%">Argument</th>
+<th>What it does</th>
+</tr>
+<tr>
+<td><code>process_name="notepad.exe"</code></td>
+<td>Looks up the PID by name. Most natural way for desktop apps and games.</td>
+</tr>
+<tr>
+<td><code>pid=1234</code></td>
+<td>Skip the name lookup and attach to a known PID directly.</td>
+</tr>
+</table>
+
+If you pass **both**, `pid` wins. If you pass **neither**, `TypeError` is raised.
+
+## Name matching: case and partial matches
+
+By default, `process_name` matching is:
+
+- **Case-sensitive** on Linux and macOS.
+- **Case-insensitive** on Windows (matches the OS convention).
+- **Exact**: the name has to match the executable name exactly.
+
+You can override both with keyword arguments:
+
+```python
+# Match "chrome.exe", "ChroMe.EXE", "chrome" — anywhere case-insensitively.
+OpenProcess(process_name="chrome", case_sensitive=False, exact_match=False)
+```
+
+| Argument | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `case_sensitive` | `bool` | platform-dependent | When `False`, ignores case. |
+| `exact_match` | `bool` | `True` | When `False`, matches as a substring. |
+
+If a partial match resolves to **more than one** process, an
+`AmbiguousProcessNameError` is raised — pick one PID from the listed candidates
+and pass it via `pid=` instead.
+
+## Permissions (Windows-only)
+
+Only the Windows backend accepts a `permission=` mask — it maps directly to the
+[`PROCESS_*` access rights](https://learn.microsoft.com/en-us/windows/win32/procthread/process-security-and-access-rights)
+of `OpenProcess`. The default opens a **read + write** handle:
+
+```python
+# Default — same as:
+OpenProcess(
+    process_name="notepad.exe",
+    permission=(
+        ProcessOperationsEnum.PROCESS_VM_READ
+        | ProcessOperationsEnum.PROCESS_VM_WRITE
+        | ProcessOperationsEnum.PROCESS_VM_OPERATION
+        | ProcessOperationsEnum.PROCESS_QUERY_INFORMATION
+    ),
+)
+```
+
+For a read-only handle (less powerful but useful for static analysis):
+
+```python
+from PyMemoryEditor import OpenProcess, ProcessOperationsEnum
+
+OpenProcess(
+    process_name="notepad.exe",
+    permission=ProcessOperationsEnum.PROCESS_VM_READ
+        | ProcessOperationsEnum.PROCESS_QUERY_INFORMATION,
+)
+```
+
+For full control:
+
+```python
+OpenProcess(
+    process_name="notepad.exe",
+    permission=ProcessOperationsEnum.PROCESS_ALL_ACCESS,
+)
+```
+
+```{admonition} 🐧🍎 On Linux and macOS
+:class: note
+
+The `permission` argument is **ignored** — those platforms govern access via
+`ptrace_scope` (Linux) or Mach entitlements (macOS). Passing a value emits a
+`UserWarning` so a Windows-shaped mask doesn't disappear silently.
+
+See [Platform Notes](../platform-notes.md) for details.
+```
+
+## Closing the handle
+
+When you're done, close the process:
+
+```python
+process.close()
+```
+
+Or use the context manager (recommended):
+
+```python
+with OpenProcess(pid=1234) as process:
+    ...
+# process is closed here, even if an exception was raised
+```
+
+Once closed, any further call raises `ClosedProcess`.
+
+## Common errors
+
+| Exception | Meaning |
+| --- | --- |
+| `ProcessNotFoundError` | No process matches the given `process_name`. |
+| `ProcessIDNotExistsError` | The given `pid` doesn't exist on the system. |
+| `AmbiguousProcessNameError` | More than one process matches a partial name — pick a PID from `.pids`. |
+| `PermissionError` | The OS denied access — usually fixable; see [Troubleshooting](../troubleshooting.md). |
+| `ClosedProcess` | Operation attempted on an already-closed handle. |
+
+All exceptions inherit from `PyMemoryEditorError`, so you can catch them
+collectively:
+
+```python
+from PyMemoryEditor import OpenProcess, PyMemoryEditorError
+
+try:
+    with OpenProcess(process_name="game.exe") as process:
+        ...
+except PyMemoryEditorError as e:
+    print("Failed to open process:", e)
+```

--- a/docs/guide/pattern-scan.md
+++ b/docs/guide/pattern-scan.md
@@ -1,0 +1,144 @@
+# Pattern scan (AOB / regex)
+
+A **pattern scan** locates *data by its shape* rather than its value — the
+technique Cheat Engine, IDA and Ghidra use to find code or data that moves
+between builds. PyMemoryEditor accepts three input forms, all powered by the
+same `search_by_pattern` method.
+
+## When to use it
+
+<table>
+<tr><td width="40%"><b>You want…</b></td><td><b>Use this</b></td></tr>
+<tr><td>Find every email address in memory</td><td>Regex pattern</td></tr>
+<tr><td>Locate a function whose absolute address changes between builds</td><td>IDA-style byte signature with wildcards</td></tr>
+<tr><td>Recognize a custom struct header</td><td>Regex or IDA-style pattern</td></tr>
+</table>
+
+## Three pattern formats
+
+### 1. IDA-style byte signature
+
+The format used by almost every public AOB recipe online — space-separated
+hex bytes with `?` or `??` as one-byte wildcards:
+
+```python
+for address in process.search_by_pattern("48 8B ? ? 00 00 89 ?"):
+    print(f"Match at 0x{address:X}")
+```
+
+- Each token is **one byte**.
+- Whitespace between tokens is free-form.
+- `?` and `??` both mean *"any byte"*.
+
+The number of matched bytes is inferred from the token count — you don't have
+to pass `byte_length=`.
+
+### 2. Raw bytes regex
+
+Pass a `bytes` object — it's compiled with `re.DOTALL` so `.` matches any byte
+(including `\n`, which is what you want when scanning binary memory):
+
+```python
+# Every email address in memory
+email = rb"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}"
+
+for address in process.search_by_pattern(email, byte_length=128):
+    raw = process.read_process_memory(address, bytes, 128)
+    print(address, raw.split(b"\x00", 1)[0].decode("ascii", "replace"))
+```
+
+```{admonition} byte_length is required for regex
+:class: warning
+
+A regex doesn't have a fixed match width, so the scanner can't infer one.
+Pass `byte_length=` set to the **maximum** number of bytes one match can
+consume. The scanner uses it to compute chunk-overlap so matches that span a
+chunk boundary aren't missed.
+```
+
+### 3. Pre-compiled `re.Pattern[bytes]`
+
+If you reuse the same pattern many times:
+
+```python
+import re
+
+pattern = re.compile(rb"PLAYER_\d+", re.DOTALL)
+
+for address in process.search_by_pattern(pattern, byte_length=32):
+    print(hex(address))
+```
+
+Same rule: `byte_length=` is required.
+
+## Method signature
+
+```{eval-rst}
+.. py:method:: search_by_pattern(pattern, *, byte_length=0, progress_information=False, memory_regions=None)
+   :no-index:
+
+   :param pattern: an IDA-style hex string, a raw bytes regex, or a compiled
+      ``re.Pattern[bytes]``.
+   :param int byte_length: required for regex / compiled patterns — the maximum
+      number of bytes one match can consume. Ignored for IDA-style strings.
+   :param bool progress_information: when ``True``, yields ``(address, info)``
+      tuples (same shape as :py:meth:`search_by_value`).
+   :param memory_regions: optional snapshot from
+      :py:meth:`snapshot_memory_regions` to skip region enumeration on iterative
+      workflows.
+   :returns: a generator of addresses (or ``(address, info)`` tuples).
+```
+
+## Examples in the wild
+
+### Locating a function after a patch
+
+```python
+# Cheat Engine signature for a known function body.
+pattern = "48 89 5C 24 ? 57 48 83 EC 20 48 8B D9 48 8B FA"
+
+for address in process.search_by_pattern(pattern):
+    print(f"Function at 0x{address:X}")
+```
+
+Because the byte signature stays stable across recompilations (only the
+addresses change), this finds the same function in every build.
+
+### Harvesting data from memory
+
+```python
+import re
+
+# Match an IPv4 address as ASCII.
+ipv4 = re.compile(rb"(?<![\d.])(\d{1,3}\.){3}\d{1,3}(?!\d)")
+
+for address in process.search_by_pattern(ipv4, byte_length=64):
+    raw = process.read_process_memory(address, bytes, 64)
+    print(address, raw.split(b"\x00", 1)[0].decode("ascii", "replace"))
+```
+
+### Combining with the refine workflow
+
+Pattern scans take a `memory_regions=` snapshot just like value scans:
+
+```python
+regions = process.snapshot_memory_regions()
+
+for address in process.search_by_pattern(pattern, memory_regions=regions):
+    ...
+```
+
+## Compiling patterns yourself
+
+The pattern compiler is available as a standalone helper, useful for testing
+without a live process:
+
+```python
+from PyMemoryEditor.util.pattern import compile_pattern
+
+regex, byte_length = compile_pattern("48 8B ? 00 00")
+print(regex.pattern, byte_length)
+# b'\\x48\\x8B.\\x00\\x00' 5
+```
+
+See [Utilities API](../api/utilities.md) for the full reference.

--- a/docs/guide/pointer-scan.md
+++ b/docs/guide/pointer-scan.md
@@ -1,0 +1,175 @@
+# Pointer scan (reverse)
+
+A scanned address is gone the next launch — the OS loads everything somewhere
+new every time (ASLR). A pointer chain is the cure, but where do you *get* the
+chain?
+
+**`scan_pointer_paths`** is the inverse of `resolve_pointer_chain`: give it the
+value's address *right now*, and the library finds the static paths
+(`module + offsets`) that lead to it.
+
+## The basic scan
+
+```python
+# The value is at this address right now (e.g. from search_by_value).
+for path in process.scan_pointer_paths(0x1FA3C140):
+    print(path)
+    # "game.exe"+0x10F4F4 -> [+0x0] -> +0x158
+    print(hex(path.resolve(process)))
+```
+
+Each result is a `PointerPath` — see [API reference](../api/pointer-path.md).
+It carries everything you need to reconstruct the chain in another run.
+
+## Method signature
+
+```{eval-rst}
+.. py:method:: scan_pointer_paths(target_address, *, max_depth=5, max_offset=0x400, ptr_size=8, aligned=True, writable_only=True, static_ranges=None, max_results=None, memory_regions=None, progress_callback=None)
+   :no-index:
+
+   :param int target_address: the dynamic address to find pointer paths to
+      (typically just found via :py:meth:`search_by_value`).
+   :param int max_depth: maximum number of pointer levels (offsets) in a chain.
+      Deeper scans find more paths but cost exponentially more — 1–7 is typical.
+   :param int max_offset: largest positive offset a single hop may add (the
+      struct-size window). Bigger values catch fields deeper inside objects at
+      the cost of many more candidate paths.
+   :param int ptr_size: pointer width — ``8`` (default) for 64-bit, ``4`` for 32-bit.
+   :param bool aligned: only consider pointers at natural alignment (default,
+      much faster). Set ``False`` to also scan misaligned slots (slow).
+   :param bool writable_only: build the pointer map from writable memory only
+      (default — faster and usually correct).
+   :param static_ranges: explicit ``(start, size)`` ranges to treat as valid
+      chain bases. Defaults to the image range of every loaded module.
+   :param int max_results: stop after yielding this many paths.
+      Recommended for shallow exploration.
+   :param memory_regions: optional snapshot from
+      :py:meth:`snapshot_memory_regions`.
+   :param callable progress_callback: ``callback(fraction)`` invoked as the
+      pointer map is built (the long phase), ``fraction`` in ``[0, 1]``.
+   :returns: a generator of :py:class:`PointerPath`.
+```
+
+## Tuning the scan
+
+A first scan usually finds **many** candidates. Start narrow and widen only if
+needed:
+
+```python
+for path in process.scan_pointer_paths(
+    address,
+    max_depth=2,        # start shallow
+    max_offset=0x100,   # smaller struct window
+    max_results=20,     # don't enumerate forever
+):
+    print(path)
+```
+
+The cost grows **exponentially** with `max_depth` — going from 4 to 6 is
+usually a 10× slowdown.
+
+```{admonition} macOS note
+:class: tip
+
+On macOS, `ModuleInfo.size` covers only the `__TEXT` segment, so global
+pointers in `__DATA` may fall outside the default static set. The library
+overrides this by walking every Mach-O segment internally, but if you pass
+`static_ranges=` explicitly, remember to include `__DATA` ranges as well.
+```
+
+## Narrowing down to the real pointer
+
+The reliable pointers are the ones that keep working **after** the value
+moves. So you save a scan, restart the target, and rescan — keeping only the
+paths that still land on the value. Repeat a couple of times and a handful of
+solid pointers remain.
+
+### Save → restart → rescan
+
+```python
+# Run 1 — scan and save.
+pointer_paths = process.scan_pointer_paths(address)
+process.save_pointer_paths(pointer_paths, "scan1.json")
+
+# ... close the target, restart it, find the value's new address again ...
+
+# Run 2 — keep only the saved paths that still reach it.
+survivors = process.rescan_pointer_paths("scan1.json", new_address)
+process.save_pointer_paths(survivors, "scan2.json")
+```
+
+### Compare independent scans
+
+Prefer working from independent scans? Save one per run, then **intersect**
+them — the paths present in *every* file are your stable pointers (no live
+address needed):
+
+```python
+stable = process.compare_pointer_scans(
+    "scan1.json", "scan2.json", "scan3.json",
+)
+```
+
+Once you're down to one pointer, use it forever:
+
+```python
+live = path.rebase(process).to_pointer(process, pytype=int, bufflength=4)
+live.value = 9999
+```
+
+## Persistence helpers
+
+<table>
+<tr><th>Method</th><th>What it does</th></tr>
+<tr><td><code>save_pointer_paths(paths, file)</code></td><td>Serialize a list of paths to a JSON file.</td></tr>
+<tr><td><code>load_pointer_paths(file)</code></td><td>Re-create the list from a saved file.</td></tr>
+<tr><td><code>rescan_pointer_paths(paths, target)</code></td><td>Keep only the paths that still resolve to <code>target</code>.</td></tr>
+<tr><td><code>compare_pointer_scans(*sources)</code></td><td>Intersect several saved scans — paths present in every one.</td></tr>
+</table>
+
+The saved file stores each path's **module + offsets** — the ASLR-independent
+part — so it stays valid even though absolute addresses change.
+
+## The `PointerPath` dataclass
+
+A summary of the methods you'll use most:
+
+```{eval-rst}
+.. py:class:: PointerPath
+   :no-index:
+
+   .. py:method:: resolve(process)
+      :no-index:
+
+      Walk this path in ``process`` and return the final target address.
+
+   .. py:method:: to_pointer(process, *, pytype=int, bufflength=None)
+      :no-index:
+
+      Build a live :py:class:`RemotePointer` for the value at the end of this
+      path.
+
+   .. py:method:: rebase(process)
+      :no-index:
+
+      Return a copy with ``base_address`` recomputed from the module's
+      **current** load address — the call that makes a saved path valid again
+      after a restart.
+
+   .. py:method:: to_dict()
+      :no-index:
+
+      Serialise to a JSON-friendly dict (hex strings) for export.
+
+   .. py:classmethod:: from_dict(data)
+      :no-index:
+
+      Rebuild a :py:class:`PointerPath` from :py:meth:`to_dict` output.
+```
+
+See the full reference at [API → PointerPath](../api/pointer-path.md).
+
+```{seealso}
+- [Pointers](pointers.md) — walking chains you already know.
+- [API → PointerPath](../api/pointer-path.md)
+```

--- a/docs/guide/pointers.md
+++ b/docs/guide/pointers.md
@@ -1,0 +1,199 @@
+# Pointers
+
+In a running program, most values you care about are reached through a
+**pointer chain** — a static base address plus a series of offsets that
+ultimately land on the value. Cheat Engine's "pointer scan" feature is built
+around this idea, and PyMemoryEditor offers the same workflow:
+
+- **`resolve_pointer_chain`** — walk a chain you already know.
+- **`RemotePointer`** — a live, re-resolving handle that re-walks the chain on
+  every read/write.
+- **`scan_pointer_paths`** — the reverse operation: find chains that resolve
+  to a given address. See [Pointer scan](pointer-scan.md).
+
+## Why pointer chains?
+
+A scanned address (`0x1FA3C140`) typically **changes every run**: the OS loads
+modules at randomized base addresses (ASLR), and the heap allocates objects in
+different places each time you launch the program.
+
+A **multi-level pointer**, in contrast, expresses a value as
+`module + offset → [+x] → [+y] → …`. The *static base* (the module + static
+offset) doesn't change between runs once ASLR is accounted for, so the same
+recipe works every time.
+
+## Walking a chain
+
+`resolve_pointer_chain` performs the walk and returns the **final address**
+where the value lives:
+
+```python
+# Cheat-table entry:  "game.exe" + 0x10F4F4 -> [+0x0] -> [+0x158]
+module = next(m for m in process.get_modules() if m.name == "game.exe")
+base = module.base_address + 0x10F4F4
+
+hp_address = process.resolve_pointer_chain(base, [0x0, 0x158])
+hp = process.read_process_memory(hp_address, int, 4)
+```
+
+### Method signature
+
+```{eval-rst}
+.. py:method:: resolve_pointer_chain(base_address, offsets, *, ptr_size=8)
+   :no-index:
+
+   Walk a multi-level pointer chain.
+
+   Reads ``ptr_size`` bytes at ``base_address`` to obtain the first pointer,
+   then for each offset in ``offsets[:-1]`` adds the offset and dereferences
+   again. The **last** offset is added *without* dereferencing — the returned
+   integer is the final address where the value of interest lives.
+
+   :param int base_address: starting address — typically
+      ``module_base + static_offset``.
+   :param Sequence[int] offsets: sequence of offsets to walk. Pass ``[]`` to
+      dereference ``base_address`` once and return that pointer.
+   :param int ptr_size: pointer width — ``8`` for 64-bit targets (default),
+      ``4`` for 32-bit.
+   :returns: the final address (an ``int``).
+```
+
+```{admonition} 32-bit vs 64-bit
+:class: warning
+
+Pass `ptr_size=4` when the target is a 32-bit process; pass `ptr_size=8` (the
+default) for 64-bit. Mixing them up reads pointers of the wrong width and
+yields garbage addresses.
+```
+
+## Live pointers: `RemotePointer`
+
+`resolve_pointer_chain` finds an address **once**. A `RemotePointer` wraps the
+same recipe in a **reusable handle** — every time you read `.value`, the chain
+is re-walked, so the handle keeps working even as the target moves things
+around the heap.
+
+```python
+# A handle to the player's HP, behind a two-level pointer.
+hp_ptr = process.get_pointer(
+    base + 0x10F4F4,
+    [0x0, 0x158],
+    pytype=int,
+    bufflength=4,
+)
+
+print(hp_ptr.value)   # read it
+hp_ptr.value = 9999   # write it
+```
+
+### Direct vs chained handles
+
+The `offsets` argument controls what `RemotePointer` does on every access:
+
+<table>
+<tr><th><code>offsets</code></th><th>Behavior</th></tr>
+<tr><td><code>None</code> <em>(default)</em></td><td><b>Direct handle</b>: <code>address</code> = <code>base_address</code>, no dereferencing. Use this to wrap an address you already have (e.g. from <code>search_by_value</code>).</td></tr>
+<tr><td><code>[]</code> (empty list)</td><td>Dereferences <code>base_address</code> once and reads the value at that pointer.</td></tr>
+<tr><td><code>[o1, o2, ...]</code></td><td>Walks the chain on every access — <code>resolve_pointer_chain</code> semantics.</td></tr>
+</table>
+
+### Pointer arithmetic
+
+`RemotePointer` supports C-style arithmetic. Adding an integer returns a
+**new** handle, without touching memory:
+
+```python
+# Mana is stored right after HP, so just step 4 bytes forward.
+mp_ptr = hp_ptr + 4
+print(mp_ptr.value)
+```
+
+You can also subtract two pointers to get a byte distance:
+
+```python
+distance = mp_ptr - hp_ptr   # 4
+```
+
+### `RemotePointer` API
+
+```{eval-rst}
+.. py:class:: RemotePointer(process, base_address, offsets=None, *, pytype=int, bufflength=None, ptr_size=8)
+   :no-index:
+
+   A re-resolving, read/write handle to a typed value in a target process.
+
+   .. py:property:: process
+      :no-index:
+
+      The :py:class:`AbstractProcess` this pointer reads from / writes to.
+
+   .. py:property:: base_address
+      :no-index:
+
+      The starting address the pointer was built with.
+
+   .. py:property:: offsets
+      :no-index:
+
+      The pointer-chain offsets, or ``None`` for a direct handle.
+
+   .. py:property:: address
+      :no-index:
+
+      The address the value currently lives at — recomputed on every access
+      for a pointer chain.
+
+   .. py:property:: value
+      :no-index:
+
+      Read or write the value at :py:attr:`address` using the bound type.
+
+   .. py:method:: read(pytype=None, bufflength=None)
+      :no-index:
+
+      Read the value at :py:attr:`address`, optionally overriding the bound
+      type for one-off reads.
+
+   .. py:method:: write(value, pytype=None, bufflength=None)
+      :no-index:
+
+      Write ``value`` to :py:attr:`address`, optionally overriding the bound
+      type.
+
+   .. py:method:: __add__(delta)
+      :no-index:
+
+      ``ptr + n`` → a new pointer ``n`` bytes ahead.
+
+   .. py:method:: __sub__(other)
+      :no-index:
+
+      ``ptr - n`` → a new pointer ``n`` bytes behind.
+      ``ptr - other`` (where ``other`` is a ``RemotePointer``) → the byte
+      distance between the two resolved addresses.
+
+   .. py:method:: __int__()
+      :no-index:
+
+      The resolved :py:attr:`address` — handy for arithmetic and logging.
+```
+
+## Building a handle from `process.get_pointer()`
+
+A small convenience wrapper around the constructor:
+
+```python
+ptr = process.get_pointer(
+    base_address=module.base_address + 0x10F4F4,
+    offsets=[0x0, 0x158],
+    pytype=int,
+    bufflength=4,
+    ptr_size=8,
+)
+```
+
+```{seealso}
+- [Pointer scan](pointer-scan.md) — discover chains that resolve to a given
+  address.
+- [API reference](../api/remote-pointer.md) — full `RemotePointer` reference.
+```

--- a/docs/guide/read-write.md
+++ b/docs/guide/read-write.md
@@ -1,0 +1,130 @@
+# Reading and writing memory
+
+`read_process_memory` and `write_process_memory` are the two building blocks of
+PyMemoryEditor. Once you know an address, you read or write it like any other
+Python variable.
+
+## Supported types
+
+PyMemoryEditor supports the **five primitive Python types** typically found in
+process memory:
+
+<table>
+<tr><th>Type</th><th>Default size</th><th>Notes</th></tr>
+<tr><td><code>int</code></td><td><b>4 bytes</b></td><td>Signed integer. Override to 1/2/8 for other widths.</td></tr>
+<tr><td><code>float</code></td><td><b>8 bytes</b></td><td><code>double</code> by default; pass 4 for <code>float32</code>.</td></tr>
+<tr><td><code>bool</code></td><td><b>1 byte</b></td><td>C <code>bool</code>.</td></tr>
+<tr><td><code>str</code></td><td>— (required)</td><td>UTF-8 decoded with <code>errors="replace"</code>.</td></tr>
+<tr><td><code>bytes</code></td><td>— (required)</td><td>Raw, no decoding.</td></tr>
+</table>
+
+For numeric types, you can pass `bufflength=None` (or just omit it) to use the
+default. For `str` and `bytes`, you **must** pass the size.
+
+## Reading a value
+
+```python
+from PyMemoryEditor import OpenProcess
+
+with OpenProcess(process_name="notepad.exe") as process:
+    address = 0x0005000C
+
+    # Integers — 4 bytes by default
+    score = process.read_process_memory(address, int)
+
+    # 1-byte integer
+    flag = process.read_process_memory(address, int, 1)
+
+    # 8-byte float (double)
+    speed = process.read_process_memory(address, float)
+
+    # 32 bytes interpreted as a UTF-8 string
+    name = process.read_process_memory(address, str, 32)
+
+    # Raw bytes (no decoding)
+    raw = process.read_process_memory(address, bytes, 16)
+```
+
+### Method signature
+
+```{eval-rst}
+.. py:method:: read_process_memory(address, pytype, bufflength=None)
+   :no-index:
+
+   :param int address: target memory address.
+   :param Type pytype: one of ``bool``, ``int``, ``float``, ``str``, ``bytes``.
+   :param int bufflength: value size in bytes. Optional for numeric types;
+      required for ``str`` / ``bytes``.
+   :return: the decoded value.
+```
+
+```{admonition} String decoding
+:class: tip
+
+When `pytype=str` the raw bytes are decoded with `errors="replace"` — invalid
+UTF-8 becomes the replacement character `U+FFFD` instead of raising.
+If you need the bytes verbatim, pass `pytype=bytes`.
+```
+
+## Writing a value
+
+```python
+with OpenProcess(process_name="notepad.exe") as process:
+    address = 0x0005000C
+
+    # Write an int (None = default size of 4 bytes)
+    process.write_process_memory(address, int, None, 9999)
+
+    # Write a 2-byte int explicitly
+    process.write_process_memory(address, int, 2, 42)
+
+    # Write a string
+    process.write_process_memory(address, str, 32, "Hello!")
+
+    # Write raw bytes
+    process.write_process_memory(address, bytes, 4, b"\xDE\xAD\xBE\xEF")
+```
+
+### Method signature
+
+```{eval-rst}
+.. py:method:: write_process_memory(address, pytype, bufflength, value)
+   :no-index:
+
+   :param int address: target memory address.
+   :param Type pytype: one of ``bool``, ``int``, ``float``, ``str``, ``bytes``.
+   :param int bufflength: value size in bytes (``None`` for numeric types to use
+      the default).
+   :param value: the value to write.
+   :return: the written value.
+```
+
+## Common errors
+
+- **`OSError`** — the address may have been freed between scan and write, or
+  the page might not be writable. Wrap one-off writes in `try/except OSError`.
+- **`PermissionError`** — the handle was opened without write access (Windows
+  read-only handle). See [Opening a process](opening-process.md#permissions-windows-only).
+- **`ValueError`** — `bufflength` was omitted for a `str` or `bytes` write.
+
+## Reading many addresses efficiently
+
+When you have a **list of addresses** to read, do **not** loop over
+`read_process_memory` — each call performs one syscall.
+
+Use `search_by_addresses` instead, which reads each memory page only once and
+extracts every requested address from it:
+
+```python
+addresses = [0x10000, 0x10010, 0x10020, ...]
+
+for address, value in process.search_by_addresses(int, 4, addresses):
+    print(f"0x{address:X} -> {value}")
+```
+
+On long address lists this is orders of magnitude faster.
+
+```{seealso}
+- [Searching memory](searching.md) — find addresses by value.
+- [Pointers](pointers.md) — follow multi-level pointer chains.
+```

--- a/docs/guide/searching.md
+++ b/docs/guide/searching.md
@@ -1,0 +1,207 @@
+# Searching memory
+
+The bread and butter of memory editing — find every address in the process
+that holds a value you can describe.
+
+PyMemoryEditor offers three search APIs:
+
+<table>
+<tr><th>Method</th><th>What it does</th></tr>
+<tr><td><a href="#search-by-value"><code>search_by_value</code></a></td><td>Find every address holding a specific value (with eight comparison modes).</td></tr>
+<tr><td><a href="#search-by-range"><code>search_by_value_between</code></a></td><td>Find every address whose value is inside (or outside) a range.</td></tr>
+<tr><td><a href="#search-by-addresses"><code>search_by_addresses</code></a></td><td>Look up the values at a known list of addresses — the refine step.</td></tr>
+</table>
+
+For locating **code or byte patterns** (AOB / signatures), see the dedicated
+[Pattern scan guide](pattern-scan.md).
+
+## Search by value
+
+```python
+from PyMemoryEditor import OpenProcess
+
+with OpenProcess(process_name="game.exe") as process:
+    for address in process.search_by_value(int, 4, 100):
+        print(f"Found at 0x{address:X}")
+```
+
+`search_by_value` is a **generator** — it yields one match at a time as it
+scans. Wrap it with `list(...)` only if you actually need every match in
+memory.
+
+### Method signature
+
+```{eval-rst}
+.. py:method:: search_by_value(pytype, bufflength, value, scan_type=ScanTypesEnum.EXACT_VALUE, *, progress_information=False, writeable_only=False, memory_regions=None)
+   :no-index:
+
+   :param Type pytype: ``bool``, ``int``, ``float``, ``str`` or ``bytes``.
+   :param int bufflength: value size in bytes (1, 2, 4, 8). Pass ``None`` for
+      numeric types to use the default.
+   :param value: the value to look for.
+   :param ScanTypesEnum scan_type: comparison mode — see below.
+   :param bool progress_information: when ``True``, yields ``(address, info)`` tuples
+      so you can update a progress bar.
+   :param bool writeable_only: when ``True``, only scans writable regions
+      (faster, drops read-only static data).
+   :param memory_regions: an optional snapshot — see :ref:`refine-scan-workflow`.
+   :returns: a generator of addresses (or ``(address, info)`` tuples).
+```
+
+### Comparison modes
+
+The optional `scan_type` controls how each value in memory is compared to your
+target. Every mode is a member of `ScanTypesEnum`:
+
+<table>
+<tr><th>Mode</th><th>Match when…</th></tr>
+<tr><td><code>EXACT_VALUE</code> <em>(default)</em></td><td>value == target</td></tr>
+<tr><td><code>NOT_EXACT_VALUE</code></td><td>value != target</td></tr>
+<tr><td><code>BIGGER_THAN</code></td><td>value &gt; target</td></tr>
+<tr><td><code>SMALLER_THAN</code></td><td>value &lt; target</td></tr>
+<tr><td><code>BIGGER_THAN_OR_EXACT_VALUE</code></td><td>value &ge; target</td></tr>
+<tr><td><code>SMALLER_THAN_OR_EXACT_VALUE</code></td><td>value &le; target</td></tr>
+<tr><td><code>VALUE_BETWEEN</code></td><td>min &le; value &le; max  (use <code>search_by_value_between</code>)</td></tr>
+<tr><td><code>NOT_VALUE_BETWEEN</code></td><td>value &lt; min or value &gt; max</td></tr>
+</table>
+
+```python
+from PyMemoryEditor import OpenProcess, ScanTypesEnum
+
+with OpenProcess(process_name="game.exe") as process:
+    # Every address that holds a value bigger than 1_000_000.
+    for address in process.search_by_value(
+        int, 4, 1_000_000,
+        scan_type=ScanTypesEnum.BIGGER_THAN,
+    ):
+        print(hex(address))
+```
+
+### Showing progress
+
+Long scans on big processes can take a while. Pass `progress_information=True`
+to get a small dict with each match:
+
+```python
+for address, info in process.search_by_value(int, 4, target, progress_information=True):
+    pct = info["progress"] * 100
+    print(f"0x{address:X} | {pct:5.1f}%")
+```
+
+The `info` dict has at least a `progress` key (a float in `[0, 1]`).
+
+## Search by range
+
+For value ranges (e.g. "find every address holding 100..200"):
+
+```python
+for address in process.search_by_value_between(int, 4, 100, 200):
+    print(hex(address))
+
+# The inverse — every address whose value is OUTSIDE the range:
+for address in process.search_by_value_between(
+    int, 4, 100, 200, not_between=True,
+):
+    print(hex(address))
+```
+
+### Method signature
+
+```{eval-rst}
+.. py:method:: search_by_value_between(pytype, bufflength, start, end, *, not_between=False, progress_information=False, writeable_only=False, memory_regions=None)
+   :no-index:
+```
+
+Same parameters as `search_by_value`, plus:
+
+- `start`, `end` — the range boundaries (inclusive).
+- `not_between` — when `True`, returns values **outside** the range.
+
+## Search by addresses
+
+When you already know **which addresses to check** (typically because you
+scanned earlier), `search_by_addresses` is the right tool — it reads each
+memory **page** only once and pulls every requested address out of it.
+
+```python
+addresses = [0x10000, 0x10010, 0x10020, ...]
+
+for address, value in process.search_by_addresses(int, 4, addresses):
+    print(f"0x{address:X} -> {value}")
+```
+
+If an address falls in an unmapped page, the value is `None` (unless
+`raise_error=True`).
+
+### Method signature
+
+```{eval-rst}
+.. py:method:: search_by_addresses(pytype, bufflength, addresses, *, raise_error=False, memory_regions=None)
+   :no-index:
+
+   :param Sequence[int] addresses: addresses to inspect.
+   :param bool raise_error: when ``True``, raises ``OSError`` instead of yielding
+      ``None`` for an unreadable address.
+   :param memory_regions: optional snapshot.
+   :returns: a generator of ``(address, value)`` tuples.
+```
+
+(refine-scan-workflow)=
+
+## The refine-scan workflow
+
+For the classic Cheat-Engine loop — *"first scan → restrict → restrict"* —
+enumerate the memory regions **once** and reuse the snapshot across every
+subsequent call. On heavy targets (browsers, JVMs with 100 000+ regions) this
+is a massive win because the per-call region enumeration is the dominant cost
+otherwise.
+
+```python
+with OpenProcess(pid=1234) as process:
+    regions = process.snapshot_memory_regions()
+
+    # First pass — every address holding 100.
+    candidates = list(process.search_by_value(int, None, 100, memory_regions=regions))
+
+    # Refine — keep only those that now hold 95.
+    refined = [
+        addr
+        for addr, value in process.search_by_addresses(int, None, candidates, memory_regions=regions)
+        if value == 95
+    ]
+```
+
+All of `snapshot_memory_regions()`, `search_by_value`, `search_by_value_between`
+and `search_by_addresses` accept the same `memory_regions=` keyword. Pass an
+empty list (`[]`) to explicitly scan nothing.
+
+```{admonition} Keep the snapshot sorted
+:class: tip
+
+The snapshot is pre-sorted by base address and tagged so that helpers skip
+their per-call `sorted(...)` step on reuse. Don't reorder the returned list
+manually; if you must slice or filter, pass the result of
+`sorted(my_slice, key=...)` — the helpers re-sort defensively when the tag is
+missing.
+```
+
+## Working with strings and bytes
+
+All of the above methods work with `str` and `bytes` too:
+
+```python
+# Find every memory address holding the literal string "PLAYER".
+for address in process.search_by_value(str, 6, "PLAYER"):
+    print(hex(address))
+```
+
+For `bytes`, comparison ordering depends on your system's `byteorder` —
+something to keep in mind when using `BIGGER_THAN` / `SMALLER_THAN` on raw
+bytes.
+
+```{seealso}
+- [Pattern scan](pattern-scan.md) — find data by **shape** with regex and AOB
+  signatures.
+- [Pointers](pointers.md) — once you've found a candidate, follow it through a
+  pointer chain.
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,131 @@
+# PyMemoryEditor Documentation
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/JeanExtreme002/PyMemoryEditor/main/PyMemoryEditor/app/assets/icon.svg" alt="PyMemoryEditor logo" width="120" />
+</p>
+
+<p align="center">
+  <b>Read, write and scan the memory of any process — straight from Python.</b><br>
+  <i>One unified API. Three operating systems. No C compiler. No native build step.</i>
+</p>
+
+<p align="center">
+  Runs on <b>🪟 Windows</b> · <b>🐧 Linux</b> · <b>🍎 macOS</b> — 32-bit and 64-bit.
+</p>
+
+---
+
+## What is PyMemoryEditor?
+
+PyMemoryEditor is a pure-Python library (built on [ctypes](https://docs.python.org/3/library/ctypes.html))
+that lets you **inspect, modify and search the memory of any process running on
+your computer** — your own scripts, a game, a debugger target, anything.
+
+It exposes the same operations Cheat Engine made famous (value scans, pattern
+scans, pointer chains, pointer scans, freezing values) behind a small, friendly
+Python API that works identically on **Windows, Linux and macOS**.
+
+If you've never done memory editing before, start with the
+[Quick Start](quickstart.md). If you'd rather click than type, the bundled
+[GUI app](app.md) gives you a Cheat Engine-style interface for free.
+
+---
+
+## Why use it?
+
+<table>
+<tr>
+<td width="33%" valign="top">
+
+### 🌍 Cross-platform
+
+One API across **Windows, Linux and macOS** — the same code, no platform-specific
+branches in user-land.
+
+</td>
+<td width="33%" valign="top">
+
+### 🐍 Pure Python
+
+Pure-Python on top of `ctypes` — no C compiler, no native build step, no
+platform-specific wheels.
+
+</td>
+<td width="33%" valign="top">
+
+### 🧰 Batteries included
+
+Value scans, AOB scans, pointer chains, pointer scans, a GUI app — all the
+Cheat Engine workflows in one package.
+
+</td>
+</tr>
+</table>
+
+---
+
+## Where to next?
+
+```{toctree}
+:caption: Getting Started
+:maxdepth: 2
+
+installation
+quickstart
+```
+
+```{toctree}
+:caption: User Guide
+:maxdepth: 2
+
+guide/opening-process
+guide/read-write
+guide/searching
+guide/pattern-scan
+guide/memory-regions
+guide/modules-threads
+guide/pointers
+guide/pointer-scan
+guide/allocate-free
+guide/logging
+```
+
+```{toctree}
+:caption: The GUI App
+:maxdepth: 2
+
+app
+```
+
+```{toctree}
+:caption: API Reference
+:maxdepth: 2
+
+api/openprocess
+api/enums
+api/memory-region
+api/remote-pointer
+api/pointer-path
+api/module-info
+api/thread-info
+api/errors
+api/utilities
+```
+
+```{toctree}
+:caption: Reference
+:maxdepth: 2
+
+platform-notes
+troubleshooting
+glossary
+```
+
+---
+
+## Quick links
+
+- 📦 **PyPI:** <https://pypi.org/project/PyMemoryEditor/>
+- 🐙 **GitHub:** <https://github.com/JeanExtreme002/PyMemoryEditor>
+- 🐛 **Issues:** <https://github.com/JeanExtreme002/PyMemoryEditor/issues>
+- 📜 **License:** [MIT](https://github.com/JeanExtreme002/PyMemoryEditor/blob/main/LICENSE)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,92 @@
+# Installation
+
+PyMemoryEditor is published on [PyPI](https://pypi.org/project/PyMemoryEditor/)
+as a pure-Python wheel — there is no native build step or compiler required on
+any platform.
+
+## Requirements
+
+<table>
+<tr><td><b>Python</b></td><td>3.10 or newer</td></tr>
+<tr><td><b>Operating systems</b></td><td>🪟 Windows · 🐧 Linux · 🍎 macOS (32-bit and 64-bit)</td></tr>
+<tr><td><b>Runtime dependency</b></td><td><a href="https://pypi.org/project/psutil/"><code>psutil</code></a> (installed automatically)</td></tr>
+</table>
+
+## Install the library
+
+```bash
+pip install PyMemoryEditor
+```
+
+## Install with the bundled GUI app
+
+The library ships an optional Cheat Engine-style GUI built on **PySide6
+(Qt for Python)**. To install it, use the `app` extra:
+
+```bash
+pip install "PyMemoryEditor[app]"
+```
+
+Once installed, launch the app from any terminal:
+
+```bash
+pymemoryeditor
+```
+
+The library itself stays dependency-free — only the `app` extra pulls
+PySide6 in.
+
+See the [GUI App guide](app.md) for a tour of every feature.
+
+## Install from source
+
+```bash
+git clone https://github.com/JeanExtreme002/PyMemoryEditor.git
+cd PyMemoryEditor
+pip install -e ".[dev]"
+```
+
+The `dev` extra installs the test toolchain (`pytest`, `pytest-xdist`,
+`pytest-qt`, `hypothesis`, `mypy`, etc.) — see
+[CONTRIBUTING.md](https://github.com/JeanExtreme002/PyMemoryEditor/blob/main/CONTRIBUTING.md)
+for the development workflow.
+
+## Verifying the installation
+
+```python
+import PyMemoryEditor
+print(PyMemoryEditor.__version__)
+```
+
+If that prints a version number, you're ready to go — head to the
+[Quick Start](quickstart.md).
+
+## Platform-specific notes
+
+```{admonition} 🪟 Windows
+:class: note
+
+Works out of the box. To attach to **protected processes** (system services,
+elevated apps), run your terminal **as Administrator**.
+```
+
+```{admonition} 🐧 Linux
+:class: note
+
+Access depends on `ptrace_scope` and process ownership. If the target is **not**
+a child of the caller and `ptrace_scope=1` (the common default), you'll see a
+`PermissionError`. Run as root, or relax it:
+
+    sudo sysctl kernel.yama.ptrace_scope=0
+```
+
+```{admonition} 🍎 macOS
+:class: note
+
+Opening **another** process requires the Python binary to be signed with the
+`com.apple.security.cs.debugger` entitlement (or SIP disabled and root).
+**Opening the current process** always works — handy for self-inspection and
+experimentation.
+```
+
+For the long version, see [Platform Notes](platform-notes.md).

--- a/docs/platform-notes.md
+++ b/docs/platform-notes.md
@@ -1,0 +1,203 @@
+# Platform Notes
+
+PyMemoryEditor abstracts away the OS, but the OS still gets a say in **what
+you're allowed to touch**. This page documents the differences that matter
+for real-world use.
+
+A one-line summary:
+
+<table>
+<tr><th>Platform</th><th>Permission model</th><th>Allocate / free</th></tr>
+<tr><td>🪟 <b>Windows</b></td><td><code>OpenProcess</code> access mask</td><td>✅ <code>VirtualAllocEx</code> / <code>VirtualFreeEx</code></td></tr>
+<tr><td>🐧 <b>Linux</b></td><td><code>ptrace_scope</code> + process ownership</td><td>❌ Not supported</td></tr>
+<tr><td>🍎 <b>macOS</b></td><td>Mach entitlements (<code>com.apple.security.cs.debugger</code>) or SIP off + root</td><td>✅ <code>mach_vm_allocate</code> / <code>mach_vm_deallocate</code></td></tr>
+</table>
+
+---
+
+(windows)=
+
+## 🪟 Windows
+
+```{tip}
+Works out of the box for most cases.
+```
+
+### Process name matching
+
+Names are matched **case-insensitively** by default to match the OS
+convention. Pass `case_sensitive=True` to opt out.
+
+### The `permission` keyword
+
+`OpenProcess(permission=...)` accepts a `ProcessOperationsEnum` (or integer)
+mask that maps directly to the [`PROCESS_*` access rights](https://learn.microsoft.com/en-us/windows/win32/procthread/process-security-and-access-rights).
+
+The default mask is **read + write + region enumeration**:
+
+```python
+PROCESS_VM_READ | PROCESS_VM_WRITE | PROCESS_VM_OPERATION | PROCESS_QUERY_INFORMATION
+```
+
+For a **read-only** handle, narrow the mask:
+
+```python
+from PyMemoryEditor import OpenProcess, ProcessOperationsEnum
+
+with OpenProcess(
+    process_name="notepad.exe",
+    permission=ProcessOperationsEnum.PROCESS_VM_READ
+        | ProcessOperationsEnum.PROCESS_QUERY_INFORMATION,
+) as process:
+    ...
+```
+
+For full control:
+
+```python
+OpenProcess(process_name="game.exe", permission=ProcessOperationsEnum.PROCESS_ALL_ACCESS)
+```
+
+### Running as Administrator
+
+To attach to **protected processes** (system services, anti-cheat-guarded
+processes, elevated apps), run your terminal **as Administrator**.
+
+### Memory allocation
+
+`allocate_memory` defaults to `PAGE_EXECUTE_READWRITE` so the region is
+usable for both data and injected code. Pass an explicit
+`MemoryProtectionsEnum` value to narrow it.
+
+---
+
+(linux)=
+
+## 🐧 Linux
+
+```{tip}
+Access is governed by `ptrace_scope` and process ownership.
+```
+
+### The `permission` keyword
+
+**Ignored** on Linux — access is governed by `ptrace_scope` and process
+ownership. The library uses `process_vm_readv` / `process_vm_writev`, which
+don't take a permission mask.
+
+Passing `permission=` something other than `None` emits a `UserWarning`.
+
+### `ptrace_scope`
+
+Access depends on:
+
+- **Process ownership** — you can always read processes you own.
+- **`ptrace_scope`** — the kernel's policy for non-child targets.
+
+If the target is **not** a child of the caller and `ptrace_scope=1` (the
+common default), you'll see a `PermissionError`. Fixes:
+
+```bash
+# Run as root (easiest):
+sudo python my_script.py
+
+# Or relax ptrace_scope (system-wide, lasts until reboot):
+sudo sysctl kernel.yama.ptrace_scope=0
+
+# Persist it across reboots:
+echo "kernel.yama.ptrace_scope=0" | sudo tee /etc/sysctl.d/10-ptrace.conf
+```
+
+### Memory allocation — not supported
+
+Linux has no syscall to allocate memory in another process's address space —
+`mmap` only affects the calling process. PyMemoryEditor's
+`allocate_memory` / `free_memory` raise `NotImplementedError` on Linux.
+
+A proper implementation would require a **ptrace-based engine** that makes
+the target call `mmap` itself — out of scope for a pure-Python library.
+
+---
+
+(macos)=
+
+## 🍎 macOS
+
+```{tip}
+Access is governed by Mach entitlements (or SIP off + root).
+```
+
+### The `permission` keyword
+
+**Ignored** on macOS. The library uses Mach VM APIs (`task_for_pid`,
+`mach_vm_read_overwrite`, `mach_vm_write`, `mach_vm_region`), which don't
+take a permission mask.
+
+### Opening another process
+
+Requires the Python binary to be signed with the
+`com.apple.security.cs.debugger` entitlement **or** SIP disabled and running
+as root. Without either, `task_for_pid()` returns an authorization error.
+
+### Opening the current process
+
+`task_for_pid()` always succeeds for *the calling task* (we use
+`mach_task_self_` directly), so **opening your own process always works** —
+ideal for self-inspection, tests, and tutorials.
+
+```python
+import os
+from PyMemoryEditor import OpenProcess
+
+with OpenProcess(pid=os.getpid()) as process:
+    # Always works on macOS, no entitlement needed.
+    for region in process.get_memory_regions():
+        ...
+```
+
+### macOS write side effect
+
+```{admonition} ResourceWarning on macOS writes
+:class: warning
+
+`write_process_memory` on a **read-only page** transparently elevates the
+page protection via `mach_vm_protect` (with `VM_PROT_COPY`), performs the
+write, and tries to restore the original protection.
+
+**If the restore step fails** (e.g. the target task disappears mid-call),
+the library emits a `ResourceWarning` and the target page is left more
+permissive than it started. Treat the warning as a signal to investigate.
+```
+
+This side effect is unique to macOS — the Win32 and Linux backends do not
+share it. Protection elevation is opt-in on Windows (`PROCESS_VM_OPERATION`),
+and Linux doesn't need protection changes for `process_vm_writev`.
+
+### `ModuleInfo.size` quirk
+
+On macOS, `ModuleInfo.size` returns the **`__TEXT` segment size**, not the
+full module image. A single whole-module size is ill-defined for
+dyld-shared-cache dylibs.
+
+For pointer scanning, the library internally walks every Mach-O segment to
+find static ranges (so global pointers in `__DATA` *are* considered static
+bases). You only need to worry about this if you pass `static_ranges=`
+explicitly to `scan_pointer_paths`.
+
+### Allocation under the hardened runtime
+
+`allocate_memory` defaults to **read+write** (the Mach default). Requesting
+**executable** allocations may fail under the hardened runtime, particularly
+RWX on Apple Silicon.
+
+---
+
+## Summary
+
+```{admonition} Where to next?
+:class: tip
+
+- Stuck on a permission error? See [Troubleshooting](troubleshooting.md).
+- Want to allocate memory? See [Allocating and freeing](guide/allocate-free.md).
+- Need to inspect a region's flags? See [Memory regions](guide/memory-regions.md).
+```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,121 @@
+# Quick Start
+
+Five minutes from `pip install` to overwriting a value in another process.
+
+## 1. Install
+
+```bash
+pip install PyMemoryEditor
+```
+
+(See [Installation](installation.md) for the GUI app or installing from source.)
+
+## 2. Open a process
+
+PyMemoryEditor exposes a single entry point: `OpenProcess`. You can target a
+process by **name** or **PID**:
+
+```python
+from PyMemoryEditor import OpenProcess
+
+# By process name
+process = OpenProcess(process_name="notepad.exe")
+
+# Or by PID
+process = OpenProcess(pid=1234)
+```
+
+The recommended pattern is a `with` block — it closes the handle automatically:
+
+```python
+with OpenProcess(process_name="notepad.exe") as process:
+    ...
+```
+
+By default, `OpenProcess` opens a **read + write** handle. No special permission
+flag needed for the common case.
+
+## 3. Read and write a value
+
+The building blocks are `read_process_memory` and `write_process_memory`.
+For numeric types (`int`, `float`, `bool`) the size is inferred.
+
+```python
+from PyMemoryEditor import OpenProcess
+
+with OpenProcess(process_name="notepad.exe") as process:
+    address = 0x0005000C
+
+    # Read 4 bytes as an int
+    value = process.read_process_memory(address, int)
+    print("Current:", value)
+
+    # Write a new value (pass None to use the default size)
+    process.write_process_memory(address, int, None, value + 7)
+```
+
+Strings and raw bytes need an explicit size:
+
+```python
+name = process.read_process_memory(address, str, 32)
+```
+
+## 4. Run your first scan
+
+You rarely know the address of a value up front — you **find it by scanning**.
+`search_by_value` yields every address holding a given value:
+
+```python
+with OpenProcess(process_name="game.exe") as process:
+    for address in process.search_by_value(int, 4, 100):
+        print(f"Found at 0x{address:X}")
+```
+
+That's the same operation Cheat Engine performs in its **First Scan** button.
+[See the searching guide](guide/searching.md) for all eight comparison modes
+and the refine workflow.
+
+## 5. The Cheat Engine workflow
+
+The classic loop is:
+
+1. **Scan** for a value you can see (e.g. your health is `100`) — you get back
+   many candidate addresses.
+2. **Let the value change** in the target (you take damage → `95`).
+3. **Refine**: keep only the addresses that now hold the new value. Repeat
+   until one address remains — that's your value.
+4. **Read, write or freeze** it.
+
+```python
+with OpenProcess(process_name="game.exe") as process:
+    # 1. First scan — every address currently holding 100.
+    candidates = list(process.search_by_value(int, 4, 100))
+
+    # 3. After the value drops to 95 in-game, keep only the matches that agree.
+    survivors = [
+        address
+        for address, value in process.search_by_addresses(int, 4, candidates)
+        if value == 95
+    ]
+
+    # 4. Overwrite the survivors back to a high value.
+    for address in survivors:
+        process.write_process_memory(address, int, 4, 9999)
+```
+
+For big targets, see [the refine-scan workflow](guide/searching.md#the-refine-scan-workflow)
+to cache the region map once.
+
+## Next steps
+
+- 📖 [User guide](guide/opening-process.md) — every workflow, in depth.
+- 🖥️ [The bundled GUI app](app.md) — same features, no code required.
+- 📚 [API reference](api/openprocess.md) — every public class and method.
+- 🛟 [Troubleshooting](troubleshooting.md) — common errors and how to fix them.
+
+```{admonition} ⚖️ Responsible use
+:class: warning
+
+PyMemoryEditor talks to other processes through OS-level APIs. **Only point it
+at processes you own or have explicit permission to inspect.**
+```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,6 @@
+sphinx>=7.0
+furo>=2024.1.29
+myst-parser>=2.0
+linkify-it-py>=2.0
+sphinx-copybutton>=0.5
+sphinx-design>=0.5

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,173 @@
+# Troubleshooting
+
+A directory of the failures users hit most often, and how to fix each one.
+
+## Permission errors
+
+### `PermissionError` when opening another process
+
+The most common first hurdle — the OS is denying access.
+
+<table>
+<tr><th>Platform</th><th>Fix</th></tr>
+<tr><td>🪟 <b>Windows</b></td><td>Run your terminal <b>as Administrator</b>. Anti-cheat-guarded processes may still refuse — that's expected and intentional.</td></tr>
+<tr><td>🐧 <b>Linux</b></td><td>Run as root, or relax <code>ptrace_scope</code>:<br><code>sudo sysctl kernel.yama.ptrace_scope=0</code><br>Opening your own process always works.</td></tr>
+<tr><td>🍎 <b>macOS</b></td><td>The Python binary must be signed with the <code>com.apple.security.cs.debugger</code> entitlement (or SIP off + root). Opening the <em>current</em> process always works — great for trying things out.</td></tr>
+</table>
+
+See [Platform Notes](platform-notes.md) for the full story.
+
+### `PermissionError` from a specific operation (Windows)
+
+You opened the process with a narrower permission mask than the operation
+needs. The most common culprit is allocating memory without
+`PROCESS_VM_OPERATION`:
+
+```python
+from PyMemoryEditor import OpenProcess, ProcessOperationsEnum
+
+# Need PROCESS_VM_OPERATION for allocate_memory.
+with OpenProcess(
+    process_name="game.exe",
+    permission=ProcessOperationsEnum.PROCESS_VM_READ
+        | ProcessOperationsEnum.PROCESS_VM_WRITE
+        | ProcessOperationsEnum.PROCESS_VM_OPERATION
+        | ProcessOperationsEnum.PROCESS_QUERY_INFORMATION,
+) as process:
+    address = process.allocate_memory(64)
+```
+
+## Process lookup errors
+
+### `ProcessNotFoundError`
+
+No running process matches the given name. Names are **case-sensitive** by
+default on Linux/macOS and **case-insensitive** on Windows. Try:
+
+```python
+OpenProcess(process_name="chrome", exact_match=False, case_sensitive=False)
+```
+
+Or pass `pid=` directly if you can find it via `ps`, Task Manager or
+Activity Monitor.
+
+### `AmbiguousProcessNameError`
+
+More than one process matches a partial name. Pick a PID from `.pids` and
+pass it explicitly:
+
+```python
+from PyMemoryEditor import OpenProcess, AmbiguousProcessNameError
+
+try:
+    process = OpenProcess(process_name="chrome", exact_match=False)
+except AmbiguousProcessNameError as exc:
+    print("Multiple matches:", exc.pids)
+    process = OpenProcess(pid=exc.pids[0])
+```
+
+### `ProcessIDNotExistsError`
+
+The given `pid=` doesn't correspond to any running process. The PID may have
+been **recycled** between when you obtained it and when you opened it — this
+happens with short-lived processes.
+
+## Read / write failures
+
+### A scan returns nothing on Windows
+
+Region enumeration needs `PROCESS_QUERY_INFORMATION`, which the default
+permission already includes. If you passed a custom `permission=` mask,
+make sure that flag is in it.
+
+```python
+mask = ProcessOperationsEnum.PROCESS_VM_READ | ProcessOperationsEnum.PROCESS_QUERY_INFORMATION
+```
+
+### Reading an address gives garbage or raises `OSError`
+
+Two common causes:
+
+- **The page was freed** between scan and read (normal during live scans
+  against active processes). Wrap one-off reads in `try/except OSError`.
+- **The value type or size is wrong.** A 4-byte int read of an 8-byte value
+  decodes the wrong half. Double-check the `pytype` and `bufflength`.
+
+```python
+try:
+    value = process.read_process_memory(address, int, 4)
+except OSError:
+    value = None
+```
+
+### `ValueError: bufflength is required`
+
+`str` and `bytes` reads need an explicit size — only numeric types have
+defaults:
+
+```python
+# Wrong
+process.read_process_memory(address, str)
+
+# Right
+process.read_process_memory(address, str, 32)
+```
+
+### `ResourceWarning` on macOS writes
+
+The library elevated a read-only page's protection to write to it, then
+failed to restore the original protection (usually because the target task
+disappeared mid-call). The page is left more permissive than it started.
+
+Treat the warning as a signal to investigate — see
+[Platform Notes → macOS](project:#macos).
+
+## Pointer issues
+
+### `resolve_pointer_chain` returns garbage
+
+- The target is a **32-bit** process and you didn't pass `ptr_size=4`.
+- One of the offsets is wrong (off-by-one in the chain).
+- The chain is **dynamic** and has already moved — use a `RemotePointer` to
+  re-walk it on every access.
+
+### `path.rebase()` raises `ValueError`
+
+The path has no associated module — its base came from a caller-supplied
+`static_ranges`. Such paths only work in the run they were found in;
+re-discover the chain in the new run.
+
+### `path.rebase()` raises `LookupError`
+
+The module is no longer loaded in the target process. Either the module was
+unloaded, or you're looking at a different process than the one you scanned.
+
+## Logging
+
+Need more detail? PyMemoryEditor logs to a standard `logging` logger named
+`"PyMemoryEditor"` (silent by default). Turn it on to see exactly which
+pages the library skips during a scan and why:
+
+```python
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+logging.getLogger("PyMemoryEditor").setLevel(logging.DEBUG)
+```
+
+The bundled app exposes the same stream in its **Log Console**
+(Tools → Log Console).
+
+See [Logging](guide/logging.md) for advanced routing.
+
+## Reporting a bug
+
+Still stuck? Open an issue at
+[github.com/JeanExtreme002/PyMemoryEditor/issues](https://github.com/JeanExtreme002/PyMemoryEditor/issues).
+
+Please include:
+
+- The **OS** (with version) and **Python version**.
+- The exact code that triggered the failure.
+- The full traceback.
+- Any `PyMemoryEditor` log output (run with `level=logging.DEBUG`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,28 +1,29 @@
 [project]
 name = "PyMemoryEditor"
 dynamic = ["version"]
-description = "Multi-platform library developed with ctypes for reading, writing and searching at process memory, in a simple and friendly way with Python 3."
+description = "Read, write and scan process memory in a few lines of Python — Cheat Engine-style scans, pointer chains and AOB search on Windows, Linux and macOS."
 authors = [
     { name = "Jean Loui Bernard Silva de Jesus", email = "contact@jeanloui.dev" },
 ]
 license = "MIT"
 readme = "README.md"
 keywords = [
-    "memory",
-    "address",
-    "pointer",
-    "process",
-    "virtual",
-    "writer",
-    "reader",
-    "editor",
-    "override",
-    "win32", "api", "ctypes", "linux", "macos", "mach",
-    "cheat", "scanner", "debug", "track",
-    "readprocessmemory", "writeprocessmemory"
+    "cheat-engine",
+    "memory-scanner",
+    "memory-editor",
+    "process-memory",
+    "pointer-scan",
+    "aob-scan",
+    "pattern-scan",
+    "game-hacking",
+    "reverse-engineering",
+    "debugging",
+    "introspection",
+    "ctypes",
 ]
 
 classifiers = [
+    "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: MIT License",
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
@@ -37,10 +38,10 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
     "Topic :: Security",
-    "Topic :: System :: Monitoring"
+    "Topic :: System :: Monitoring",
+    "Typing :: Typed",
 ]
-exclude = ["tests", ".flake8"]
-requires-python = ">=3.6"
+requires-python = ">=3.10"
 dependencies = ["psutil>=5.9,<7"]
 
 [project.optional-dependencies]
@@ -64,8 +65,15 @@ dev = [
   "PySide6>=6.5",
 ]
 
+[project.scripts]
+pymemoryeditor = "PyMemoryEditor.app.application:main"
+
 [project.urls]
-"Homepage" = "https://github.com/JeanExtreme002/PyMemoryEditor"
+Homepage = "https://github.com/JeanExtreme002/PyMemoryEditor"
+Documentation = "https://pymemoryeditor.readthedocs.io"
+Repository = "https://github.com/JeanExtreme002/PyMemoryEditor"
+Issues = "https://github.com/JeanExtreme002/PyMemoryEditor/issues"
+Changelog = "https://github.com/JeanExtreme002/PyMemoryEditor/releases"
 
 [tool.mypy]
 # The Qt app uses dynamic types and depends on the optional PySide6 GUI
@@ -108,9 +116,6 @@ exclude = ["scripts"]
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[project.scripts]
-pymemoryeditor = "PyMemoryEditor.app.application:main"
 
 # Coverage scope: the Qt app is excluded — it's exercised manually, not by
 # the automated test suite. The library code (everything else) is what we

--- a/tests/test_module_enumeration.py
+++ b/tests/test_module_enumeration.py
@@ -83,7 +83,7 @@ def test_module_base_matches_a_real_memory_region():
     """
     with OpenProcess(pid=os.getpid()) as process:
         modules = list(process.get_modules())
-        region_starts = {region["address"] for region in process.get_memory_regions()}
+        region_starts = {region.address for region in process.get_memory_regions()}
 
     matched = sum(1 for m in modules if m.base_address in region_starts)
     assert matched > 0, (

--- a/tests/test_region_snapshot.py
+++ b/tests/test_region_snapshot.py
@@ -17,20 +17,25 @@ if sys.platform not in ("win32", "darwin") and not sys.platform.startswith("linu
     pytest.skip("Platform not supported by PyMemoryEditor", allow_module_level=True)
 
 
-from PyMemoryEditor import OpenProcess  # noqa: E402
+from PyMemoryEditor import MemoryRegion, MemoryRegionSnapshot, OpenProcess  # noqa: E402
 
 
 def test_snapshot_returns_materialized_list():
     process = OpenProcess(pid=os.getpid())
     try:
         snapshot = process.snapshot_memory_regions()
+        # MemoryRegionSnapshot is a list subclass — the helpers in
+        # process.scanning rely on this isinstance check to skip the per-call
+        # sorted() step.
         assert isinstance(snapshot, list)
+        assert isinstance(snapshot, MemoryRegionSnapshot)
         assert len(snapshot) > 0
-        # Each entry should expose the same shape as get_memory_regions().
+        # Each entry should expose the dataclass fields.
         first = snapshot[0]
-        assert "address" in first
-        assert "size" in first
-        assert "struct" in first
+        assert isinstance(first, MemoryRegion)
+        assert isinstance(first.address, int)
+        assert isinstance(first.size, int)
+        assert first.struct is not None
     finally:
         process.close()
 
@@ -41,8 +46,8 @@ def test_snapshot_can_be_iterated_multiple_times():
     try:
         snapshot = process.snapshot_memory_regions()
         # Two passes yield identical content.
-        addresses_pass_1 = [r["address"] for r in snapshot]
-        addresses_pass_2 = [r["address"] for r in snapshot]
+        addresses_pass_1 = [r.address for r in snapshot]
+        addresses_pass_2 = [r.address for r in snapshot]
         assert addresses_pass_1 == addresses_pass_2
     finally:
         process.close()

--- a/tests/test_scanning_helper.py
+++ b/tests/test_scanning_helper.py
@@ -15,12 +15,21 @@ import ctypes
 
 import pytest
 
+from PyMemoryEditor.process.region import MemoryRegion
 from PyMemoryEditor.process.scanning import iter_values_for_addresses
 
 
-def _make_region(address: int, payload: bytes) -> dict:
-    """Build a fake region dict matching what get_memory_regions() yields."""
-    return {"address": address, "size": len(payload), "_payload": payload}
+# Tests build fake regions as ``MemoryRegion`` instances and keep the payload
+# bytes in a side-channel dict keyed by base address (the dataclass is frozen,
+# so attaching a payload to the region itself isn't an option). The
+# ``_make_reader`` closure walks the regions and serves bytes from that dict.
+_FAKE_PAYLOADS: "dict[int, bytes]" = {}
+
+
+def _make_region(address: int, payload: bytes) -> MemoryRegion:
+    """Build a fake region matching what get_memory_regions() yields."""
+    _FAKE_PAYLOADS[address] = payload
+    return MemoryRegion(address=address, size=len(payload), is_readable=True)
 
 
 def _make_reader(regions):
@@ -32,11 +41,11 @@ def _make_reader(regions):
 
     def read_chunk(address: int, size: int):
         for region in regions:
-            base = region["address"]
-            end = base + region["size"]
+            base = region.address
+            end = base + region.size
             if base <= address and address + size <= end:
                 offset = address - base
-                slice_ = region["_payload"][offset : offset + size]
+                slice_ = _FAKE_PAYLOADS[base][offset : offset + size]
                 buf = (ctypes.c_byte * len(slice_))()
                 ctypes.memmove(buf, slice_, len(slice_))
                 return buf

--- a/tests/test_str_boundary.py
+++ b/tests/test_str_boundary.py
@@ -16,21 +16,28 @@ next chunk when the value type is ``str``, completing the straddling decode.
 import ctypes
 
 from PyMemoryEditor.enums import ScanTypesEnum
+from PyMemoryEditor.process.region import MemoryRegion
 from PyMemoryEditor.process.scanning import iter_search_results
 
 
-def _make_region(address: int, payload: bytes) -> dict:
-    return {"address": address, "size": len(payload), "_payload": payload}
+# Payload bytes keyed by region base address — the dataclass is frozen so the
+# raw bytes live in this side-channel dict (the reader closure reaches into it).
+_FAKE_PAYLOADS: "dict[int, bytes]" = {}
+
+
+def _make_region(address: int, payload: bytes) -> MemoryRegion:
+    _FAKE_PAYLOADS[address] = payload
+    return MemoryRegion(address=address, size=len(payload), is_readable=True)
 
 
 def _make_reader(region):
     def read_chunk(addr: int, size: int):
-        base = region["address"]
+        base = region.address
         offset = addr - base
         end = offset + size
         # Mimic how a backend reads: clamp at region end so over-reads still
         # return what's available rather than raising.
-        payload = region["_payload"][offset:end]
+        payload = _FAKE_PAYLOADS[base][offset:end]
         buf = (ctypes.c_byte * len(payload))()
         ctypes.memmove(buf, payload, len(payload))
         return buf


### PR DESCRIPTION
- Region API: replace untyped region dicts with a frozen MemoryRegion dataclass + MemoryRegionSnapshot (list subclass that tags pre-sorted snapshots so scan helpers can skip the per-call sorted()). The enrich_region(dict) / _PRESORTED_KEY pattern is gone — backends call make_region(address, size, struct) and all consumers do dot-access. Predicates (is_region_readable, etc.) now operate on the raw platform struct.

- Docs: new docs/ tree built with Sphinx + MyST + Furo, ready for ReadTheDocs (.readthedocs.yaml). Quick start, full per-topic user guide, complete API reference (including MemoryRegion), GUI app guide, platform notes, troubleshooting, glossary. README slimmed down to a vitrine that links into the docs.

- Makefile: install-docs / docs / docs-serve / docs-clean targets.

- pyproject.toml polish: rewritten description for PyPI search, requires-python fixed to >=3.10 (matched classifiers/README/badges), dead `exclude = ` removed, keywords tightened to high-signal terms (cheat-engine, memory-scanner, pointer-scan, aob-scan, …), URLs expanded (Documentation/Repository/Issues/Changelog), Typing::Typed and Development Status::5 classifiers added, [project.scripts] moved up to the rest of [project.*].

- Misc: docs/_build/ added to .gitignore; macos/types.py docstring updated to reference MemoryRegion.struct; app/memory_map_dialog.py preserves MemoryRegionSnapshot type across signal hops.

Tests + mypy + flake8 all clean.

**Why is this PR necessary, what does it do?**

<!-- 
IMPORTANT! Explain the **motivation** for making this change: what existing
problem the pull request solves or what new features it implements.
-->

**Checklist (complete all items)**:

- [ ] Added tests as necessary.
- [ ] There is no breaking change for existing features.

**References:**

<!-- (Nice to have) 
Link tasks, issues, PRs that are related to this pull request, etc. 
-->

No references to be shared. 

**Notes:**

<!-- (Optional) 
Explain some changes that can be useful when reviewing this pull request. 
-->

No notes to be shared. 