### PR TITLE
docs: reorganize nav, add GitHub CTA + teal theme, polish sidebar

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,113 @@
+/* Furo centers the layout: on wide screens the sidebar drawer spans the whole
+   left half and right-justifies its content against the text column, leaving a
+   wide margin on the far left. Pin it to a fixed width, flush against the left
+   edge of the window, for a conventional left-sidebar layout. */
+.sidebar-drawer {
+  width: 20em;
+  justify-content: flex-start;
+}
+
+/* The inner container is hardcoded to 15em in Furo; widen it to match the
+   drawer so the brand, search box and nav tree fill the extra space. */
+.sidebar-container {
+  width: 20em;
+}
+
+/* Roomier horizontal padding for the whole sidebar (brand, captions, links). */
+body {
+  --sidebar-item-spacing-horizontal: 1rem;
+}
+
+/* Center the brand block (logo + project name) so it lines up with the
+   centered GitHub button below it. Furo only adds its own `.centered` class
+   for a text logo, not for an image logo. */
+.sidebar-brand {
+  align-items: center;
+  text-align: center;
+}
+
+/* Smaller logo (Furo lets it grow to the full sidebar width by default). */
+.sidebar-logo {
+  max-width: 6em;
+}
+
+/* Furo keeps a few purple accents that don't follow the brand colour:
+   visited links and the generic admonition-title accent. Point them at the
+   teal brand colour in every theme mode (explicit light/dark + auto). */
+body {
+  --color-brand-visited: var(--color-brand-content);
+  --color-admonition-title: var(--color-brand-content);
+}
+@media not print {
+  body[data-theme="dark"] {
+    --color-brand-visited: var(--color-brand-content);
+    --color-admonition-title: var(--color-brand-content);
+  }
+  @media (prefers-color-scheme: dark) {
+    body:not([data-theme="light"]) {
+      --color-brand-visited: var(--color-brand-content);
+      --color-admonition-title: var(--color-brand-content);
+    }
+  }
+}
+
+/* Pygments (light theme): retint the purple keyword tokens to the teal accent.
+   Dark-theme keywords are already green, so they have no purple to fix. */
+.highlight .k,
+.highlight .kc,
+.highlight .kd,
+.highlight .kn,
+.highlight .kp,
+.highlight .kr,
+.highlight .ne,
+.highlight .ow {
+  color: #0d9488;
+}
+
+/* "Why use it?" feature grid on the landing page: add horizontal breathing
+   room between the three columns without overflowing (border-box keeps the
+   33% widths intact), and zero out the outer edges. */
+.feature-grid td {
+  box-sizing: border-box;
+  padding: 0 1.25rem;
+  /* Shrink the cell text; the `h3` headings use `em`, so the title and body
+     scale down together proportionally. */
+  font-size: 0.85rem;
+}
+.feature-grid td:first-child {
+  padding-left: 0;
+}
+.feature-grid td:last-child {
+  padding-right: 0;
+}
+
+/* Persistent GitHub call-to-action in the sidebar, under the project name. */
+.sidebar-github-cta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin: 0.75rem 1rem 0.25rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-background-border);
+  border-radius: 0.5rem;
+  color: var(--color-sidebar-link-text);
+  font-size: 0.85rem;
+  font-weight: 600;
+  line-height: 1;
+  text-decoration: none;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.sidebar-github-cta:hover,
+.sidebar-github-cta:focus-visible {
+  background: var(--color-background-hover);
+  border-color: var(--color-foreground-border);
+  color: var(--color-sidebar-link-text);
+}
+
+.sidebar-github-cta svg {
+  width: 1.15em;
+  height: 1.15em;
+  flex-shrink: 0;
+}

--- a/docs/_templates/sidebar/brand.html
+++ b/docs/_templates/sidebar/brand.html
@@ -1,0 +1,26 @@
+{#- Furo's default brand, plus a persistent GitHub call-to-action pinned
+    directly under the project name so it's visible from every page. -#}
+<a class="sidebar-brand{% if logo %} centered{% endif %}" href="{{ pathto(master_doc) }}">
+  {%- block brand_content %}
+  {%- if logo_url %}
+  <div class="sidebar-logo-container">
+    <img class="sidebar-logo" src="{{ logo_url }}" alt="Logo"/>
+  </div>
+  {%- endif %}
+  {%- if theme_light_logo and theme_dark_logo %}
+  <div class="sidebar-logo-container">
+    <img class="sidebar-logo only-light" src="{{ pathto('_static/' + theme_light_logo, 1) }}" alt="Light Logo"/>
+    <img class="sidebar-logo only-dark" src="{{ pathto('_static/' + theme_dark_logo, 1) }}" alt="Dark Logo"/>
+  </div>
+  {%- endif %}
+  {% if not theme_sidebar_hide_name %}
+  <span class="sidebar-brand-text">{{ docstitle if docstitle else project }}</span>
+  {%- endif %}
+  {% endblock brand_content %}
+</a>
+<a class="sidebar-github-cta" href="https://github.com/JeanExtreme002/PyMemoryEditor" target="_blank" rel="noopener noreferrer">
+  <svg aria-hidden="true" viewBox="0 0 16 16" stroke="currentColor" fill="currentColor" stroke-width="0">
+    <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path>
+  </svg>
+  <span>View on GitHub</span>
+</a>

--- a/docs/api/enums.md
+++ b/docs/api/enums.md
@@ -2,7 +2,12 @@
 
 ## `ScanTypesEnum`
 
-Comparison modes for `search_by_value` and `search_by_value_between`.
+```{eval-rst}
+.. py:class:: ScanTypesEnum
+
+   Comparison modes for :py:meth:`search_by_value` and
+   :py:meth:`search_by_value_between`.
+```
 
 ```python
 from PyMemoryEditor import ScanTypesEnum
@@ -35,6 +40,13 @@ with OpenProcess(process_name="game.exe") as process:
 ---
 
 ## `ProcessOperationsEnum` <small>(Windows only)</small>
+
+```{eval-rst}
+.. py:class:: ProcessOperationsEnum
+
+   Bitmask of Windows process access rights, passed as the ``permission=``
+   argument of ``OpenProcess`` on Windows.
+```
 
 Bitmask of [process access rights](https://learn.microsoft.com/en-us/windows/win32/procthread/process-security-and-access-rights).
 Defined as `IntFlag` so members can be combined with `|`:
@@ -80,6 +92,12 @@ This is enough for both read and write operations plus region enumeration
 ---
 
 ## `MemoryProtectionsEnum` <small>(Windows only)</small>
+
+```{eval-rst}
+.. py:class:: MemoryProtectionsEnum
+
+   The Win32 ``PAGE_*`` page-protection constants.
+```
 
 The Win32 `PAGE_*` constants. Used as the `permission=` argument of
 `allocate_memory` and surfaced in `region["struct"].Protect`.

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -32,10 +32,18 @@ more idiomatic match (`PermissionError`, `OSError`, `TypeError`, `ValueError`,
 
 ### `PyMemoryEditorError`
 
+```{eval-rst}
+.. py:exception:: PyMemoryEditorError
+```
+
 Base class for every PyMemoryEditor-specific exception. Catch it to handle
 *any* library error.
 
 ### `ClosedProcess`
+
+```{eval-rst}
+.. py:exception:: ClosedProcess
+```
 
 Raised when you call any method on a process whose handle has already been
 closed (manually or by leaving the `with` block).
@@ -52,10 +60,12 @@ process.read_process_memory(0x1000, int)   # raises ClosedProcess
 Raised when the given `pid=` doesn't correspond to a running process.
 
 ```{eval-rst}
-.. py:attribute:: pid
-   :type: int
+.. py:exception:: ProcessIDNotExistsError
 
-   The PID that was looked up.
+   .. py:attribute:: pid
+      :type: int
+
+      The PID that was looked up.
 ```
 
 ### `ProcessNotFoundError`
@@ -63,10 +73,12 @@ Raised when the given `pid=` doesn't correspond to a running process.
 Raised when no running process matches the given `process_name=`.
 
 ```{eval-rst}
-.. py:attribute:: process_name
-   :type: str
+.. py:exception:: ProcessNotFoundError
 
-   The process name that was looked up.
+   .. py:attribute:: process_name
+      :type: str
+
+      The process name that was looked up.
 ```
 
 ### `AmbiguousProcessNameError`
@@ -75,16 +87,17 @@ Raised when **more than one** running process matches the given
 `process_name=` (typical when using `exact_match=False`).
 
 ```{eval-rst}
-.. py:attribute:: process_name
-   :type: str
-   :no-index:
+.. py:exception:: AmbiguousProcessNameError
 
-   The process name that was looked up.
+   .. py:attribute:: process_name
+      :type: str
 
-.. py:attribute:: pids
-   :type: List[int]
+      The process name that was looked up.
 
-   PIDs of the matching processes — pick one and pass it via ``pid=``.
+   .. py:attribute:: pids
+      :type: List[int]
+
+      PIDs of the matching processes — pick one and pass it via ``pid=``.
 ```
 
 Example:

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,33 @@
+# API Reference
+
+Every public class, method and helper PyMemoryEditor exposes. For
+task-oriented walkthroughs, see the [User Guide](../guide/index.md).
+
+## At a glance
+
+<table>
+<tr><th>Symbol</th><th>What it is</th></tr>
+<tr><td><a href="openprocess.html"><code>OpenProcess</code></a></td><td>The unified entry point — read, write, scan, allocate.</td></tr>
+<tr><td><a href="enums.html">Enums</a></td><td><code>ScanTypesEnum</code>, <code>ProcessOperationsEnum</code>, <code>MemoryProtectionsEnum</code>.</td></tr>
+<tr><td><a href="memory-region.html"><code>MemoryRegion</code></a></td><td>One region of the target's address space.</td></tr>
+<tr><td><a href="remote-pointer.html"><code>RemotePointer</code></a></td><td>A live, re-resolving handle to a typed value.</td></tr>
+<tr><td><a href="pointer-path.html"><code>PointerPath</code></a></td><td>A discovered static pointer path from a reverse scan.</td></tr>
+<tr><td><a href="module-info.html"><code>ModuleInfo</code></a></td><td>A loaded executable or shared library.</td></tr>
+<tr><td><a href="thread-info.html"><code>ThreadInfo</code></a></td><td>A thread running inside the target.</td></tr>
+<tr><td><a href="errors.html">Errors</a></td><td>The exception hierarchy.</td></tr>
+<tr><td><a href="utilities.html">Utilities</a></td><td>Low-level helpers under <code>PyMemoryEditor.util</code>.</td></tr>
+</table>
+
+```{toctree}
+:maxdepth: 1
+
+openprocess
+enums
+memory-region
+remote-pointer
+pointer-path
+module-info
+thread-info
+errors
+utilities
+```

--- a/docs/api/memory-region.md
+++ b/docs/api/memory-region.md
@@ -73,7 +73,7 @@ of memory with its address, size, permissions and backing path.
 .. py:class:: MemoryRegionSnapshot
 
    A pre-sorted snapshot of memory regions returned by
-   :py:meth:`AbstractProcess.snapshot_memory_regions`. Behaves exactly like a
+   :py:meth:`snapshot_memory_regions`. Behaves exactly like a
    plain ``list[MemoryRegion]`` — the only purpose of the subclass is to let
    the scanning helpers detect via ``isinstance`` that the input is already
    sorted by ``address`` and skip the per-call ``sorted(...)`` step.

--- a/docs/api/module-info.md
+++ b/docs/api/module-info.md
@@ -33,7 +33,7 @@ Linux, `.dylib` on macOS).
       Address where the module is loaded for this run. Combine it with a
       static offset (``base_address + offset``) to reach a known location
       despite ASLR — the natural feed into
-      :py:meth:`AbstractProcess.resolve_pointer_chain`.
+      :py:meth:`resolve_pointer_chain`.
 
    .. py:attribute:: size
       :type: int

--- a/docs/api/openprocess.md
+++ b/docs/api/openprocess.md
@@ -12,6 +12,14 @@ resolves to:
 
 All three subclass `AbstractProcess` and share the API documented below.
 
+```{eval-rst}
+.. py:class:: AbstractProcess
+
+   The cross-platform base class every backend implements. ``OpenProcess``
+   returns one of its subclasses; the methods documented on this page are the
+   shared, public surface.
+```
+
 ## Construction
 
 ```{eval-rst}
@@ -208,7 +216,7 @@ with OpenProcess(
 ```{eval-rst}
 .. py:method:: close()
 
-   Close the process handle. Subsequent calls raise :py:class:`ClosedProcess`.
+   Close the process handle. Subsequent calls raise :py:exc:`ClosedProcess`.
 
 .. py:method:: __enter__()
 .. py:method:: __exit__(exc_type, exc_value, exc_traceback)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,16 +77,30 @@ html_theme_options = {
     "source_branch": "main",
     "source_directory": "docs/",
     "light_css_variables": {
-        "color-brand-primary": "#8A2BE2",
-        "color-brand-content": "#8A2BE2",
+        "color-brand-primary": "#0D9488",
+        "color-brand-content": "#0D9488",
     },
     "dark_css_variables": {
-        "color-brand-primary": "#B57AFF",
-        "color-brand-content": "#B57AFF",
+        "color-brand-primary": "#2DD4BF",
+        "color-brand-content": "#2DD4BF",
     },
+    # Persistent GitHub call-to-action, pinned to the sidebar footer on every page.
+    "footer_icons": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/JeanExtreme002/PyMemoryEditor",
+            "html": """
+                <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 16 16">
+                    <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path>
+                </svg>
+            """,
+            "class": "",
+        },
+    ],
 }
 
 html_static_path = ["_static"]
+html_css_files = ["custom.css"]
 
 # Logo and favicon resolved from the bundled SVG icon.
 html_logo = "../PyMemoryEditor/app/assets/icon.svg"

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,0 +1,53 @@
+# User Guide
+
+Task-oriented walkthroughs of every PyMemoryEditor workflow, from opening a
+process to following multi-level pointer chains. Each page is self-contained
+and cross-links to the relevant [API reference](../api/index.md).
+
+New here? Read the [Quick Start](../quickstart.md) first, then come back for
+the in-depth version.
+
+## What's covered
+
+- **Core workflow** — open a process, read/write values, and find addresses by
+  value or byte pattern. This is the classic Cheat Engine loop.
+- **Inspecting the process** — enumerate memory regions, loaded modules and
+  threads.
+- **Pointers** — walk pointer chains you know, and reverse-scan to discover the
+  chains that survive a restart.
+- **Advanced** — reserve and release memory inside the target.
+
+For diagnostics, see [Logging](logging.md) in the Reference section.
+
+```{toctree}
+:caption: Core workflow
+:maxdepth: 1
+
+opening-process
+read-write
+searching
+pattern-scan
+```
+
+```{toctree}
+:caption: Inspecting the process
+:maxdepth: 1
+
+memory-regions
+modules-threads
+```
+
+```{toctree}
+:caption: Pointers
+:maxdepth: 1
+
+pointers
+pointer-scan
+```
+
+```{toctree}
+:caption: Advanced
+:maxdepth: 1
+
+allocate-free
+```

--- a/docs/guide/modules-threads.md
+++ b/docs/guide/modules-threads.md
@@ -51,7 +51,7 @@ with OpenProcess(process_name="game.exe") as process:
       Address where the module is loaded **for this run**. Combine it with a
       static offset (``base_address + offset``) to reach a known location
       despite ASLR — the natural feed into
-      :py:meth:`AbstractProcess.resolve_pointer_chain`.
+      :py:meth:`resolve_pointer_chain`.
 
    .. py:attribute:: size
       :no-index:

--- a/docs/guide/pointer-scan.md
+++ b/docs/guide/pointer-scan.md
@@ -45,7 +45,7 @@ It carries everything you need to reconstruct the chain in another run.
       Recommended for shallow exploration.
    :param memory_regions: optional snapshot from
       :py:meth:`snapshot_memory_regions`.
-   :param callable progress_callback: ``callback(fraction)`` invoked as the
+   :param progress_callback: a callable ``callback(fraction)`` invoked as the
       pointer map is built (the long phase), ``fraction`` in ``[0, 1]``.
    :returns: a generator of :py:class:`PointerPath`.
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ If you've never done memory editing before, start with the
 
 ## Why use it?
 
-<table>
+<table class="feature-grid">
 <tr>
 <td width="33%" valign="top">
 
@@ -53,7 +53,7 @@ platform-specific wheels.
 </td>
 <td width="33%" valign="top">
 
-### 🧰 Batteries included
+### 🧰 Complete toolkit
 
 Value scans, AOB scans, pointer chains, pointer scans, a GUI app — all the
 Cheat Engine workflows in one package.
@@ -78,16 +78,7 @@ quickstart
 :caption: User Guide
 :maxdepth: 2
 
-guide/opening-process
-guide/read-write
-guide/searching
-guide/pattern-scan
-guide/memory-regions
-guide/modules-threads
-guide/pointers
-guide/pointer-scan
-guide/allocate-free
-guide/logging
+guide/index
 ```
 
 ```{toctree}
@@ -101,15 +92,7 @@ app
 :caption: API Reference
 :maxdepth: 2
 
-api/openprocess
-api/enums
-api/memory-region
-api/remote-pointer
-api/pointer-path
-api/module-info
-api/thread-info
-api/errors
-api/utilities
+api/index
 ```
 
 ```{toctree}
@@ -118,6 +101,7 @@ api/utilities
 
 platform-notes
 troubleshooting
+guide/logging
 glossary
 ```
 


### PR DESCRIPTION
- Split the User Guide into captioned sub-groups and add guide/ and api/ landing pages; move logging into the Reference section.
- Register AbstractProcess, the exceptions and the enums as proper Sphinx objects so cross-references resolve as links (clean nitpicky build).
- Add a persistent 'View on GitHub' CTA to the sidebar (brand template override) plus a footer icon.
- Switch the brand accent from purple to teal and retint the remaining purple bits (visited links, admonition titles, light-theme code keywords).
- Widen the sidebar to 20em flush-left, center the brand, shrink the logo, and add spacing to the landing-page feature grid.

**Why is this PR necessary, what does it do?**

<!-- 
IMPORTANT! Explain the **motivation** for making this change: what existing
problem the pull request solves or what new features it implements.
-->

**Checklist (complete all items)**:

- [ ] Added tests as necessary.
- [ ] There is no breaking change for existing features.

**References:**

<!-- (Nice to have) 
Link tasks, issues, PRs that are related to this pull request, etc. 
-->

No references to be shared. 

**Notes:**

<!-- (Optional) 
Explain some changes that can be useful when reviewing this pull request. 
-->

No notes to be shared. 