### PR TITLE
docs: rename example section heading to 'See it in action'

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ pymemoryeditor
 
 ---
 
-## A 60-second taste
+## See it in action
 
 ```python
 from PyMemoryEditor import OpenProcess


### PR DESCRIPTION
## Summary
- Renames the README example section heading from "A 60-second taste" to "See it in action".