### PR TITLE
docs: responsive mobile layout for the documentation site

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -13,6 +13,18 @@
   width: 20em;
 }
 
+/* Below Furo's mobile breakpoint (63em) the sidebar becomes an off-canvas
+   drawer that Furo hides at `left: -15em` to match its default 15em width.
+   Our 20em override above leaves the extra 5em poking out past the left edge
+   of the screen. Push it the full 20em off-screen so it stays fully hidden
+   until the menu toggle slides it back to `left: 0`. */
+@media (max-width: 63em) {
+  .sidebar-drawer {
+    width: 20em;
+    left: -20em;
+  }
+}
+
 /* Roomier horizontal padding for the whole sidebar (brand, captions, links). */
 body {
   --sidebar-item-spacing-horizontal: 1rem;
@@ -79,6 +91,99 @@ body {
 }
 .feature-grid td:last-child {
   padding-right: 0;
+}
+
+/* "When to use the app vs the library": two side-by-side "when to use" cards
+   on desktop that stack vertically on mobile (handled by the breakpoint below). */
+.vs-cards {
+  display: flex;
+  gap: 1rem;
+}
+.vs-card {
+  flex: 1;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--color-background-border);
+  border-radius: 0.5rem;
+}
+/* Tighten the card's inner spacing so the title and list sit snugly. */
+.vs-card > :first-child {
+  margin-top: 0;
+}
+.vs-card > :last-child {
+  margin-bottom: 0;
+}
+
+@media (max-width: 410px) {
+  .main-title {
+    font-size: 32px;
+  }
+}
+/* --- Mobile (below Furo's 63em breakpoint) layout tweaks for the landing page --- */
+@media (max-width: 63em) {
+  /* Stack the "Why use it?" feature columns vertically instead of side by side.
+     The cells are table-cells by default; switch the row to a flex column so
+     each feature occupies the full width on its own line. */
+  .feature-grid,
+  .feature-grid tbody,
+  .feature-grid tr,
+  .inside-grid,
+  .inside-grid tbody,
+  .inside-grid tr {
+    display: flex;
+    flex-direction: column;
+  }
+  .feature-grid td,
+  .inside-grid td {
+    width: 100%;
+    padding: 0;
+  }
+
+  /* Stack the two "when to use" cards on top of each other. */
+  .vs-cards {
+    flex-direction: column;
+  }
+
+  /* Every other content table (data / comparison / lookup) turns each row into
+     a stacked card. This is a blanket rule for all tables in the page body; the
+     two layout grids above are excluded since they stack as plain blocks. */
+  article table:not(.feature-grid):not(.inside-grid) {
+    &,
+    & tbody {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    /* Header row is redundant once stacked — its labels are re-attached per
+       cell via `data-label` (multi-column tables) or implied by the title. */
+    & tr:has(th) {
+      display: none;
+    }
+    & tr {
+      display: flex;
+      flex-direction: column;
+      padding: 1rem;
+      border: 1px solid var(--color-background-border);
+      border-radius: 0.5rem;
+    }
+    & td {
+      display: block;
+      width: 100%;
+      border: 0;
+      padding: 0;
+    }
+    /* An unlabelled first cell (the name / symbol / platform) is the card
+       title: slightly larger and spaced from the details below it. */
+    & td:first-child:not([data-label]) {
+      font-size: 1.1em;
+      margin-bottom: 0.5rem;
+    }
+    /* Re-attach the column header as an inline label before each value. */
+    & td[data-label]::before {
+      content: attr(data-label) ": ";
+      font-weight: 600;
+      color: var(--color-foreground-muted);
+    }
+  }
 }
 
 /* Persistent GitHub call-to-action in the sidebar, under the project name. */

--- a/docs/api/enums.md
+++ b/docs/api/enums.md
@@ -15,14 +15,14 @@ from PyMemoryEditor import ScanTypesEnum
 
 <table>
 <tr><th>Member</th><th>Value</th><th>Matches when…</th></tr>
-<tr><td><code>EXACT_VALUE</code></td><td><code>0</code></td><td>value == target <em>(default)</em></td></tr>
-<tr><td><code>NOT_EXACT_VALUE</code></td><td><code>1</code></td><td>value != target</td></tr>
-<tr><td><code>BIGGER_THAN</code></td><td><code>2</code></td><td>value &gt; target</td></tr>
-<tr><td><code>SMALLER_THAN</code></td><td><code>3</code></td><td>value &lt; target</td></tr>
-<tr><td><code>BIGGER_THAN_OR_EXACT_VALUE</code></td><td><code>4</code></td><td>value &ge; target</td></tr>
-<tr><td><code>SMALLER_THAN_OR_EXACT_VALUE</code></td><td><code>5</code></td><td>value &le; target</td></tr>
-<tr><td><code>VALUE_BETWEEN</code></td><td><code>6</code></td><td>min &le; value &le; max (used by <code>search_by_value_between</code>)</td></tr>
-<tr><td><code>NOT_VALUE_BETWEEN</code></td><td><code>7</code></td><td>value &lt; min or value &gt; max</td></tr>
+<tr><td><code>EXACT_VALUE</code></td><td data-label="Value"><code>0</code></td><td data-label="Matches when…">value == target <em>(default)</em></td></tr>
+<tr><td><code>NOT_EXACT_VALUE</code></td><td data-label="Value"><code>1</code></td><td data-label="Matches when…">value != target</td></tr>
+<tr><td><code>BIGGER_THAN</code></td><td data-label="Value"><code>2</code></td><td data-label="Matches when…">value &gt; target</td></tr>
+<tr><td><code>SMALLER_THAN</code></td><td data-label="Value"><code>3</code></td><td data-label="Matches when…">value &lt; target</td></tr>
+<tr><td><code>BIGGER_THAN_OR_EXACT_VALUE</code></td><td data-label="Value"><code>4</code></td><td data-label="Matches when…">value &ge; target</td></tr>
+<tr><td><code>SMALLER_THAN_OR_EXACT_VALUE</code></td><td data-label="Value"><code>5</code></td><td data-label="Matches when…">value &le; target</td></tr>
+<tr><td><code>VALUE_BETWEEN</code></td><td data-label="Value"><code>6</code></td><td data-label="Matches when…">min &le; value &le; max (used by <code>search_by_value_between</code>)</td></tr>
+<tr><td><code>NOT_VALUE_BETWEEN</code></td><td data-label="Value"><code>7</code></td><td data-label="Matches when…">value &lt; min or value &gt; max</td></tr>
 </table>
 
 ### Example
@@ -62,20 +62,20 @@ mask = (
 
 <table>
 <tr><th>Member</th><th>Hex</th><th>Required for</th></tr>
-<tr><td><code>PROCESS_TERMINATE</code></td><td><code>0x0001</code></td><td><code>TerminateProcess</code></td></tr>
-<tr><td><code>PROCESS_CREATE_THREAD</code></td><td><code>0x0002</code></td><td>Creating a thread</td></tr>
-<tr><td><code>PROCESS_VM_OPERATION</code></td><td><code>0x0008</code></td><td>Allocating / freeing / changing page protection</td></tr>
-<tr><td><code>PROCESS_VM_READ</code></td><td><code>0x0010</code></td><td><code>ReadProcessMemory</code></td></tr>
-<tr><td><code>PROCESS_VM_WRITE</code></td><td><code>0x0020</code></td><td><code>WriteProcessMemory</code></td></tr>
-<tr><td><code>PROCESS_DUP_HANDLE</code></td><td><code>0x0040</code></td><td>Duplicating a handle</td></tr>
-<tr><td><code>PROCESS_CREATE_PROCESS</code></td><td><code>0x0080</code></td><td>Creating a process</td></tr>
-<tr><td><code>PROCESS_SET_QUOTA</code></td><td><code>0x0100</code></td><td>Setting memory limits</td></tr>
-<tr><td><code>PROCESS_SET_INFORMATION</code></td><td><code>0x0200</code></td><td>Setting priority class, etc.</td></tr>
-<tr><td><code>PROCESS_QUERY_INFORMATION</code></td><td><code>0x0400</code></td><td><code>VirtualQueryEx</code>, token info</td></tr>
-<tr><td><code>PROCESS_SUSPEND_RESUME</code></td><td><code>0x0800</code></td><td>Suspend/resume the process</td></tr>
-<tr><td><code>PROCESS_QUERY_LIMITED_INFORMATION</code></td><td><code>0x1000</code></td><td>Limited info queries</td></tr>
-<tr><td><code>PROCESS_SET_LIMITED_INFORMATION</code></td><td><code>0x2000</code></td><td>Limited info set</td></tr>
-<tr><td><code>PROCESS_ALL_ACCESS</code></td><td><code>0x1FFFFF</code></td><td>Everything</td></tr>
+<tr><td><code>PROCESS_TERMINATE</code></td><td data-label="Hex"><code>0x0001</code></td><td data-label="Required for"><code>TerminateProcess</code></td></tr>
+<tr><td><code>PROCESS_CREATE_THREAD</code></td><td data-label="Hex"><code>0x0002</code></td><td data-label="Required for">Creating a thread</td></tr>
+<tr><td><code>PROCESS_VM_OPERATION</code></td><td data-label="Hex"><code>0x0008</code></td><td data-label="Required for">Allocating / freeing / changing page protection</td></tr>
+<tr><td><code>PROCESS_VM_READ</code></td><td data-label="Hex"><code>0x0010</code></td><td data-label="Required for"><code>ReadProcessMemory</code></td></tr>
+<tr><td><code>PROCESS_VM_WRITE</code></td><td data-label="Hex"><code>0x0020</code></td><td data-label="Required for"><code>WriteProcessMemory</code></td></tr>
+<tr><td><code>PROCESS_DUP_HANDLE</code></td><td data-label="Hex"><code>0x0040</code></td><td data-label="Required for">Duplicating a handle</td></tr>
+<tr><td><code>PROCESS_CREATE_PROCESS</code></td><td data-label="Hex"><code>0x0080</code></td><td data-label="Required for">Creating a process</td></tr>
+<tr><td><code>PROCESS_SET_QUOTA</code></td><td data-label="Hex"><code>0x0100</code></td><td data-label="Required for">Setting memory limits</td></tr>
+<tr><td><code>PROCESS_SET_INFORMATION</code></td><td data-label="Hex"><code>0x0200</code></td><td data-label="Required for">Setting priority class, etc.</td></tr>
+<tr><td><code>PROCESS_QUERY_INFORMATION</code></td><td data-label="Hex"><code>0x0400</code></td><td data-label="Required for"><code>VirtualQueryEx</code>, token info</td></tr>
+<tr><td><code>PROCESS_SUSPEND_RESUME</code></td><td data-label="Hex"><code>0x0800</code></td><td data-label="Required for">Suspend/resume the process</td></tr>
+<tr><td><code>PROCESS_QUERY_LIMITED_INFORMATION</code></td><td data-label="Hex"><code>0x1000</code></td><td data-label="Required for">Limited info queries</td></tr>
+<tr><td><code>PROCESS_SET_LIMITED_INFORMATION</code></td><td data-label="Hex"><code>0x2000</code></td><td data-label="Required for">Limited info set</td></tr>
+<tr><td><code>PROCESS_ALL_ACCESS</code></td><td data-label="Hex"><code>0x1FFFFF</code></td><td data-label="Required for">Everything</td></tr>
 </table>
 
 ### Default permission
@@ -108,17 +108,17 @@ from PyMemoryEditor.win32.enums.memory_protections import MemoryProtectionsEnum
 
 <table>
 <tr><th>Member</th><th>Hex</th><th>Meaning</th></tr>
-<tr><td><code>PAGE_NOACCESS</code></td><td><code>0x01</code></td><td>Disables all access.</td></tr>
-<tr><td><code>PAGE_READONLY</code></td><td><code>0x02</code></td><td>Read-only.</td></tr>
-<tr><td><code>PAGE_READWRITE</code></td><td><code>0x04</code></td><td>Read + write.</td></tr>
-<tr><td><code>PAGE_WRITECOPY</code></td><td><code>0x08</code></td><td>Copy-on-write.</td></tr>
-<tr><td><code>PAGE_EXECUTE</code></td><td><code>0x10</code></td><td>Execute-only.</td></tr>
-<tr><td><code>PAGE_EXECUTE_READ</code></td><td><code>0x20</code></td><td>Read + execute.</td></tr>
-<tr><td><code>PAGE_EXECUTE_READWRITE</code></td><td><code>0x40</code></td><td>Read + write + execute. <em>(allocate_memory default)</em></td></tr>
-<tr><td><code>PAGE_EXECUTE_WRITECOPY</code></td><td><code>0x80</code></td><td>Read + execute + copy-on-write.</td></tr>
-<tr><td><code>PAGE_GUARD</code></td><td><code>0x100</code></td><td>Pages become guard pages.</td></tr>
-<tr><td><code>PAGE_NOCACHE</code></td><td><code>0x200</code></td><td>Non-cachable.</td></tr>
-<tr><td><code>PAGE_WRITECOMBINE</code></td><td><code>0x400</code></td><td>Write-combined.</td></tr>
+<tr><td><code>PAGE_NOACCESS</code></td><td data-label="Hex"><code>0x01</code></td><td data-label="Meaning">Disables all access.</td></tr>
+<tr><td><code>PAGE_READONLY</code></td><td data-label="Hex"><code>0x02</code></td><td data-label="Meaning">Read-only.</td></tr>
+<tr><td><code>PAGE_READWRITE</code></td><td data-label="Hex"><code>0x04</code></td><td data-label="Meaning">Read + write.</td></tr>
+<tr><td><code>PAGE_WRITECOPY</code></td><td data-label="Hex"><code>0x08</code></td><td data-label="Meaning">Copy-on-write.</td></tr>
+<tr><td><code>PAGE_EXECUTE</code></td><td data-label="Hex"><code>0x10</code></td><td data-label="Meaning">Execute-only.</td></tr>
+<tr><td><code>PAGE_EXECUTE_READ</code></td><td data-label="Hex"><code>0x20</code></td><td data-label="Meaning">Read + execute.</td></tr>
+<tr><td><code>PAGE_EXECUTE_READWRITE</code></td><td data-label="Hex"><code>0x40</code></td><td data-label="Meaning">Read + write + execute. <em>(allocate_memory default)</em></td></tr>
+<tr><td><code>PAGE_EXECUTE_WRITECOPY</code></td><td data-label="Hex"><code>0x80</code></td><td data-label="Meaning">Read + execute + copy-on-write.</td></tr>
+<tr><td><code>PAGE_GUARD</code></td><td data-label="Hex"><code>0x100</code></td><td data-label="Meaning">Pages become guard pages.</td></tr>
+<tr><td><code>PAGE_NOCACHE</code></td><td data-label="Hex"><code>0x200</code></td><td data-label="Meaning">Non-cachable.</td></tr>
+<tr><td><code>PAGE_WRITECOMBINE</code></td><td data-label="Hex"><code>0x400</code></td><td data-label="Meaning">Write-combined.</td></tr>
 </table>
 
 ### Convenience composites

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -5,7 +5,7 @@ task-oriented walkthroughs, see the [User Guide](../guide/index.md).
 
 ## At a glance
 
-<table>
+<table class="glance-grid">
 <tr><th>Symbol</th><th>What it is</th></tr>
 <tr><td><a href="openprocess.html"><code>OpenProcess</code></a></td><td>The unified entry point — read, write, scan, allocate.</td></tr>
 <tr><td><a href="enums.html">Enums</a></td><td><code>ScanTypesEnum</code>, <code>ProcessOperationsEnum</code>, <code>MemoryProtectionsEnum</code>.</td></tr>

--- a/docs/api/pointer-path.md
+++ b/docs/api/pointer-path.md
@@ -37,11 +37,11 @@ hashable.
 
 <table>
 <tr><th>Attribute</th><th>Type</th><th>Meaning</th></tr>
-<tr><td><code>base_address</code></td><td><code>int</code></td><td>Absolute static base for the run the path was found in.</td></tr>
-<tr><td><code>offsets</code></td><td><code>Tuple[int, ...]</code></td><td>Forward-order offsets.</td></tr>
-<tr><td><code>module</code></td><td><code>Optional[str]</code></td><td>Module owning <code>base_address</code>.</td></tr>
-<tr><td><code>module_offset</code></td><td><code>Optional[int]</code></td><td><code>base_address - module.base_address</code>.</td></tr>
-<tr><td><code>ptr_size</code></td><td><code>int</code></td><td>Pointer width (4 or 8).</td></tr>
+<tr><td><code>base_address</code></td><td data-label="Type"><code>int</code></td><td data-label="Meaning">Absolute static base for the run the path was found in.</td></tr>
+<tr><td><code>offsets</code></td><td data-label="Type"><code>Tuple[int, ...]</code></td><td data-label="Meaning">Forward-order offsets.</td></tr>
+<tr><td><code>module</code></td><td data-label="Type"><code>Optional[str]</code></td><td data-label="Meaning">Module owning <code>base_address</code>.</td></tr>
+<tr><td><code>module_offset</code></td><td data-label="Type"><code>Optional[int]</code></td><td data-label="Meaning"><code>base_address - module.base_address</code>.</td></tr>
+<tr><td><code>ptr_size</code></td><td data-label="Type"><code>int</code></td><td data-label="Meaning">Pointer width (4 or 8).</td></tr>
 </table>
 
 ## Methods

--- a/docs/app.md
+++ b/docs/app.md
@@ -33,7 +33,7 @@ name or PID.
 
 ## What's inside
 
-<table>
+<table class="inside-grid">
 <tr>
 <td width="50%" valign="top">
 
@@ -120,12 +120,26 @@ The pointer-scan format is documented in [`PointerPath`](api/pointer-path.md).
 
 ## When to use the app vs the library
 
-<table>
-<tr><th>Use the GUI when…</th><th>Use the library when…</th></tr>
-<tr><td>You're exploring a target interactively.</td><td>You want to script a workflow or build a tool.</td></tr>
-<tr><td>You're learning memory editing.</td><td>You want to embed memory access into a bigger application.</td></tr>
-<tr><td>You want to inspect what's available before writing code.</td><td>You need batch processing, automation, or CI integration.</td></tr>
-</table>
+<div class="vs-cards">
+<div class="vs-card">
+
+**Use the GUI when…**
+
+- You're exploring a target interactively.
+- You're learning memory editing.
+- You want to inspect what's available before writing code.
+
+</div>
+<div class="vs-card">
+
+**Use the library when…**
+
+- You want to script a workflow or build a tool.
+- You want to embed memory access into a bigger application.
+- You need batch processing, automation, or CI integration.
+
+</div>
+</div>
 
 ```{seealso}
 - [Quick Start](quickstart.md) — the same workflow, in code.

--- a/docs/guide/allocate-free.md
+++ b/docs/guide/allocate-free.md
@@ -65,7 +65,7 @@ process.free_memory(address, size=4096)
 
 ## Platform behavior
 
-<table>
+<table class="platform-grid">
 <tr>
 <th>Platform</th>
 <th>Status</th>
@@ -73,22 +73,22 @@ process.free_memory(address, size=4096)
 <th>Underlying API</th>
 </tr>
 <tr>
-<td>🪟 <b>Windows</b></td>
-<td>✅ Supported</td>
-<td><code>PAGE_EXECUTE_READWRITE</code> (executable + writable)</td>
-<td><code>VirtualAllocEx</code> / <code>VirtualFreeEx</code></td>
+<td class="platform-name">🪟 <b>Windows</b></td>
+<td data-label="Status">✅ Supported</td>
+<td data-label="Default permission"><code>PAGE_EXECUTE_READWRITE</code> (executable + writable)</td>
+<td data-label="Underlying API"><code>VirtualAllocEx</code> / <code>VirtualFreeEx</code></td>
 </tr>
 <tr>
-<td>🍎 <b>macOS</b></td>
-<td>✅ Supported</td>
-<td>Mach default (read+write)</td>
-<td><code>mach_vm_allocate</code> / <code>mach_vm_deallocate</code></td>
+<td class="platform-name">🍎 <b>macOS</b></td>
+<td data-label="Status">✅ Supported</td>
+<td data-label="Default permission">Mach default (read+write)</td>
+<td data-label="Underlying API"><code>mach_vm_allocate</code> / <code>mach_vm_deallocate</code></td>
 </tr>
 <tr>
-<td>🐧 <b>Linux</b></td>
-<td>❌ <b>Not supported</b></td>
-<td>—</td>
-<td>Raises <code>NotImplementedError</code></td>
+<td class="platform-name">🐧 <b>Linux</b></td>
+<td data-label="Status">❌ <b>Not supported</b></td>
+<td data-label="Default permission">—</td>
+<td data-label="Underlying API">Raises <code>NotImplementedError</code></td>
 </tr>
 </table>
 

--- a/docs/guide/memory-regions.md
+++ b/docs/guide/memory-regions.md
@@ -30,14 +30,14 @@ Each region is an instance of `MemoryRegion` — an immutable
 
 <table>
 <tr><th>Field</th><th>Type</th><th>Meaning</th></tr>
-<tr><td><code>address</code></td><td><code>int</code></td><td>Base address of the region.</td></tr>
-<tr><td><code>size</code></td><td><code>int</code></td><td>Region size in bytes.</td></tr>
-<tr><td><code>is_readable</code></td><td><code>bool</code></td><td>True if the region can be read.</td></tr>
-<tr><td><code>is_writable</code></td><td><code>bool</code></td><td>True if the region can be written.</td></tr>
-<tr><td><code>is_executable</code></td><td><code>bool</code></td><td>True if the region contains executable code.</td></tr>
-<tr><td><code>is_shared</code></td><td><code>bool</code></td><td>True if the region is a shared/file-backed mapping.</td></tr>
-<tr><td><code>path</code></td><td><code>str</code></td><td>File backing the region (Linux only — empty on Windows/macOS).</td></tr>
-<tr><td><code>struct</code></td><td>platform-specific</td><td>Raw platform descriptor (see below).</td></tr>
+<tr><td><code>address</code></td><td data-label="Type"><code>int</code></td><td data-label="Meaning">Base address of the region.</td></tr>
+<tr><td><code>size</code></td><td data-label="Type"><code>int</code></td><td data-label="Meaning">Region size in bytes.</td></tr>
+<tr><td><code>is_readable</code></td><td data-label="Type"><code>bool</code></td><td data-label="Meaning">True if the region can be read.</td></tr>
+<tr><td><code>is_writable</code></td><td data-label="Type"><code>bool</code></td><td data-label="Meaning">True if the region can be written.</td></tr>
+<tr><td><code>is_executable</code></td><td data-label="Type"><code>bool</code></td><td data-label="Meaning">True if the region contains executable code.</td></tr>
+<tr><td><code>is_shared</code></td><td data-label="Type"><code>bool</code></td><td data-label="Meaning">True if the region is a shared/file-backed mapping.</td></tr>
+<tr><td><code>path</code></td><td data-label="Type"><code>str</code></td><td data-label="Meaning">File backing the region (Linux only — empty on Windows/macOS).</td></tr>
+<tr><td><code>struct</code></td><td data-label="Type">platform-specific</td><td data-label="Meaning">Raw platform descriptor (see below).</td></tr>
 </table>
 
 ```{admonition} Immutability

--- a/docs/guide/pattern-scan.md
+++ b/docs/guide/pattern-scan.md
@@ -8,7 +8,7 @@ same `search_by_pattern` method.
 ## When to use it
 
 <table>
-<tr><td width="40%"><b>You want…</b></td><td><b>Use this</b></td></tr>
+<tr><th width="40%">You want…</th><th>Use this</th></tr>
 <tr><td>Find every email address in memory</td><td>Regex pattern</td></tr>
 <tr><td>Locate a function whose absolute address changes between builds</td><td>IDA-style byte signature with wildcards</td></tr>
 <tr><td>Recognize a custom struct header</td><td>Regex or IDA-style pattern</td></tr>

--- a/docs/guide/read-write.md
+++ b/docs/guide/read-write.md
@@ -11,11 +11,11 @@ process memory:
 
 <table>
 <tr><th>Type</th><th>Default size</th><th>Notes</th></tr>
-<tr><td><code>int</code></td><td><b>4 bytes</b></td><td>Signed integer. Override to 1/2/8 for other widths.</td></tr>
-<tr><td><code>float</code></td><td><b>8 bytes</b></td><td><code>double</code> by default; pass 4 for <code>float32</code>.</td></tr>
-<tr><td><code>bool</code></td><td><b>1 byte</b></td><td>C <code>bool</code>.</td></tr>
-<tr><td><code>str</code></td><td>— (required)</td><td>UTF-8 decoded with <code>errors="replace"</code>.</td></tr>
-<tr><td><code>bytes</code></td><td>— (required)</td><td>Raw, no decoding.</td></tr>
+<tr><td><code>int</code></td><td data-label="Default size"><b>4 bytes</b></td><td data-label="Notes">Signed integer. Override to 1/2/8 for other widths.</td></tr>
+<tr><td><code>float</code></td><td data-label="Default size"><b>8 bytes</b></td><td data-label="Notes"><code>double</code> by default; pass 4 for <code>float32</code>.</td></tr>
+<tr><td><code>bool</code></td><td data-label="Default size"><b>1 byte</b></td><td data-label="Notes">C <code>bool</code>.</td></tr>
+<tr><td><code>str</code></td><td data-label="Default size">— (required)</td><td data-label="Notes">UTF-8 decoded with <code>errors="replace"</code>.</td></tr>
+<tr><td><code>bytes</code></td><td data-label="Default size">— (required)</td><td data-label="Notes">Raw, no decoding.</td></tr>
 </table>
 
 For numeric types, you can pass `bufflength=None` (or just omit it) to use the

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# PyMemoryEditor Documentation
+# <span class="main-title">PyMemoryEditor Documentation</span>
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/JeanExtreme002/PyMemoryEditor/main/PyMemoryEditor/app/assets/icon.svg" alt="PyMemoryEditor logo" width="120" />

--- a/docs/platform-notes.md
+++ b/docs/platform-notes.md
@@ -6,11 +6,11 @@ for real-world use.
 
 A one-line summary:
 
-<table>
+<table class="platform-grid">
 <tr><th>Platform</th><th>Permission model</th><th>Allocate / free</th></tr>
-<tr><td>🪟 <b>Windows</b></td><td><code>OpenProcess</code> access mask</td><td>✅ <code>VirtualAllocEx</code> / <code>VirtualFreeEx</code></td></tr>
-<tr><td>🐧 <b>Linux</b></td><td><code>ptrace_scope</code> + process ownership</td><td>❌ Not supported</td></tr>
-<tr><td>🍎 <b>macOS</b></td><td>Mach entitlements (<code>com.apple.security.cs.debugger</code>) or SIP off + root</td><td>✅ <code>mach_vm_allocate</code> / <code>mach_vm_deallocate</code></td></tr>
+<tr><td class="platform-name">🪟 <b>Windows</b></td><td data-label="Permission model"><code>OpenProcess</code> access mask</td><td data-label="Allocate / free">✅ <code>VirtualAllocEx</code> / <code>VirtualFreeEx</code></td></tr>
+<tr><td class="platform-name">🐧 <b>Linux</b></td><td data-label="Permission model"><code>ptrace_scope</code> + process ownership</td><td data-label="Allocate / free">❌ Not supported</td></tr>
+<tr><td class="platform-name">🍎 <b>macOS</b></td><td data-label="Permission model">Mach entitlements (<code>com.apple.security.cs.debugger</code>) or SIP off + root</td><td data-label="Allocate / free">✅ <code>mach_vm_allocate</code> / <code>mach_vm_deallocate</code></td></tr>
 </table>
 
 ---

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -106,6 +106,46 @@ with OpenProcess(process_name="game.exe") as process:
 For big targets, see [the refine-scan workflow](guide/searching.md#the-refine-scan-workflow)
 to cache the region map once.
 
+## 6. Pointer scanning — make an address survive restarts
+
+The address you just found is **useless next launch**. The OS loads everything
+somewhere new every time (ASLR), so `0x1FA3C140` today is garbage tomorrow.
+The fix is a **static pointer path**: a chain that starts at a fixed location
+inside a loaded module and dereferences its way to your value — so the same
+recipe keeps working across restarts.
+
+PyMemoryEditor finds these for you. `scan_pointer_paths` is a **reverse pointer
+scan** (Cheat Engine's "Pointer scan"): give it the value's address *right now*,
+and it discovers the static paths that resolve to it.
+
+```python
+with OpenProcess(process_name="game.exe") as process:
+    # The value lives here this run (e.g. from search_by_value above).
+    for path in process.scan_pointer_paths(0x1FA3C140, max_depth=4):
+        print(path)
+        # "game.exe"+0x10F4F4 -> [+0x0] -> +0x158
+        print(hex(path.resolve(process)))
+```
+
+Each result is a `PointerPath` carrying the module + offsets — the part that
+survives a restart. Save the reliable ones and reuse them later:
+
+```python
+with OpenProcess(process_name="game.exe") as process:
+    paths = list(process.scan_pointer_paths(0x1FA3C140, max_depth=4))
+    process.save_pointer_paths(paths, "health.json")
+
+# ...next launch, the absolute address has changed but the path still works:
+with OpenProcess(process_name="game.exe") as process:
+    survivors = process.rescan_pointer_paths("health.json", 0x2B7C0140)
+    pointer = survivors[0].rebase(process).to_pointer(process)
+    pointer.write(9999)
+```
+
+[See the pointer scan guide](guide/pointer-scan.md) for tuning the scan
+(`max_depth`, `max_offset`), the multi-run refine workflow, and intersecting
+independent scans with `compare_pointer_scans`.
+
 ## Next steps
 
 - 📖 [User guide](guide/opening-process.md) — every workflow, in depth.


### PR DESCRIPTION
## Summary

Makes the Sphinx/Furo documentation site usable on mobile by stacking its multi-column layouts into single-column cards below Furo's 63em breakpoint.

### Changes
- **Sidebar drawer**: push the off-canvas drawer the full 20em off-screen so the 5em overflow from our width override stays hidden until toggled.
- **Landing page grids**: stack the "Why use it?" feature columns and the "When to use the app vs the library" cards vertically on small screens.
- **Content tables**: turn each row of data/comparison/lookup tables into a stacked card, hide the now-redundant header row, and re-attach column headers inline per cell via `data-label`.
- Minor title font-size tweak for very narrow screens, plus small doc copy/markup updates across the guide and API pages to support the new layout.

All changes are documentation-only (CSS + Markdown); no library code is affected.