### PR TITLE
feat: detect target bitness and auto-default pointer width

### DIFF
--- a/PyMemoryEditor/linux/functions.py
+++ b/PyMemoryEditor/linux/functions.py
@@ -275,6 +275,59 @@ def get_modules(pid: int) -> Generator[ModuleInfo, None, None]:
         )
 
 
+def _read_elf_class(path: str) -> Optional[int]:
+    """
+    Read the ``EI_CLASS`` byte from an ELF file's identification header.
+
+    Returns 1 for ELFCLASS32, 2 for ELFCLASS64, or ``None`` if ``path`` can't
+    be opened or isn't an ELF file (missing ``\\x7fELF`` magic).
+    """
+    try:
+        with open(path, "rb") as elf:
+            ident = elf.read(5)
+    except OSError:
+        return None
+
+    if len(ident) < 5 or ident[:4] != b"\x7fELF":
+        return None
+
+    return ident[4]  # e_ident[EI_CLASS]: 1 = ELFCLASS32, 2 = ELFCLASS64
+
+
+def is_process_64bit(pid: int) -> bool:
+    """
+    Return ``True`` if the target process is 64-bit, ``False`` if 32-bit.
+
+    Reads the ``EI_CLASS`` byte of the process's ELF executable. The primary
+    source is ``/proc/<pid>/exe``; if that symlink can't be read (a different
+    user without ``CAP_SYS_PTRACE``), it falls back to the first file-backed,
+    executable mapping in ``/proc/<pid>/maps`` — the main image or a shared
+    library, which share the process's bitness. As a last resort it assumes the
+    host's word size.
+    """
+    ei_class = _read_elf_class("/proc/{}/exe".format(pid))
+
+    if ei_class is None:
+        # Fallback: probe a file-backed executable mapping's on-disk ELF header.
+        for region in get_memory_regions(pid):
+            if not region.is_executable:
+                continue
+            path = region.path
+            if not path or path.startswith("["):  # skip [heap], [stack], anon
+                continue
+            ei_class = _read_elf_class(path)
+            if ei_class is not None:
+                break
+
+    if ei_class == 2:
+        return True
+    if ei_class == 1:
+        return False
+
+    # Couldn't determine it — assume the host's word size (the usual case).
+    return ctypes.sizeof(ctypes.c_void_p) == 8
+
+
 def read_process_memory(pid: int, address: int, pytype: Type[T], bufflength: int) -> T:
     """
     Return a value from a memory address.

--- a/PyMemoryEditor/linux/process.py
+++ b/PyMemoryEditor/linux/process.py
@@ -14,6 +14,7 @@ from .functions import (
     get_memory_regions,
     get_modules,
     get_threads,
+    is_process_64bit,
     read_process_memory,
     search_addresses_by_pattern,
     search_addresses_by_value,
@@ -78,6 +79,10 @@ class LinuxProcess(AbstractProcess):
     def close(self) -> bool:
         self.__closed = True
         return True
+
+    def _detect_is_64bit(self) -> bool:
+        self.__require_open()
+        return is_process_64bit(self.pid)
 
     def get_memory_regions(self) -> Generator[dict, None, None]:
         self.__require_open()

--- a/PyMemoryEditor/macos/functions.py
+++ b/PyMemoryEditor/macos/functions.py
@@ -569,6 +569,7 @@ def get_threads(task: int) -> Generator[ThreadInfo, None, None]:
 
 # Mach-O constants for sizing an image from its load commands.
 _MH_MAGIC_64 = 0xFEEDFACF
+_MH_MAGIC_32 = 0xFEEDFACE  # 32-bit image header magic (host byte order)
 _LC_SEGMENT_64 = 0x19
 _MACH_HEADER_64_SIZE = 32  # sizeof(struct mach_header_64)
 
@@ -805,6 +806,31 @@ def get_modules(task: int) -> Generator[ModuleInfo, None, None]:
             size=_macho_image_size(task, load_address),
             raw=load_address,
         )
+
+
+def is_task_64bit(task: int) -> bool:
+    """
+    Return ``True`` if the target task is 64-bit, ``False`` if 32-bit.
+
+    Reads the Mach-O header magic of a loaded image (every image in a process
+    shares its bitness): ``MH_MAGIC_64`` means 64-bit, ``MH_MAGIC`` means
+    32-bit. macOS has shipped 64-bit only since Catalina (10.15), so if no
+    image header can be read this defaults to ``True``.
+    """
+    for module in get_modules(task):
+        try:
+            magic = int.from_bytes(
+                read_process_memory(task, module.base_address, bytes, 4), "little"
+            )
+        except MachReadError:
+            continue
+        if magic == _MH_MAGIC_64:
+            return True
+        if magic == _MH_MAGIC_32:
+            return False
+
+    # No readable image header — macOS is 64-bit only on every supported release.
+    return True
 
 
 def search_addresses_by_pattern(

--- a/PyMemoryEditor/macos/process.py
+++ b/PyMemoryEditor/macos/process.py
@@ -19,6 +19,7 @@ from .functions import (
     get_modules,
     get_task_for_pid,
     get_threads,
+    is_task_64bit,
     read_process_memory,
     release_task,
     search_addresses_by_pattern,
@@ -124,6 +125,10 @@ class MacProcess(AbstractProcess):
             # __del__ must not raise; the port may already be gone if the
             # interpreter is shutting down.
             pass
+
+    def _detect_is_64bit(self) -> bool:
+        self.__require_open()
+        return is_task_64bit(self.__task)
 
     def get_memory_regions(self) -> Generator[dict, None, None]:
         self.__require_open()

--- a/PyMemoryEditor/process/abstract.py
+++ b/PyMemoryEditor/process/abstract.py
@@ -71,6 +71,10 @@ class AbstractProcess(ABC):
                 "You must pass an argument to one of these parameters (process_name, pid)."
             )
 
+        # Cache for the target's bitness — resolved lazily on first access of
+        # `is_64bit` / `pointer_size` (a syscall per backend) and reused after.
+        self._is_64bit_cache: Optional[bool] = None
+
     def __enter__(self):
         return self
 
@@ -80,6 +84,52 @@ class AbstractProcess(ABC):
     @property
     def pid(self) -> int:
         return self._process_info.pid
+
+    @abstractmethod
+    def _detect_is_64bit(self) -> bool:
+        """
+        Detect whether the target process is 64-bit. Backend-specific:
+
+        * **Windows** — ``IsWow64Process`` on a 64-bit OS (a WOW64 process is
+          32-bit), gated by the native OS architecture.
+        * **Linux** — the ``EI_CLASS`` byte of the executable's ELF header
+          (read from ``/proc/<pid>/exe`` or a file-backed image mapping).
+        * **macOS** — the Mach-O header magic of a loaded image
+          (``MH_MAGIC_64`` vs ``MH_MAGIC``).
+
+        Called once by :attr:`is_64bit`, which caches the result. Implementations
+        may assume the process is still open.
+        """
+        raise NotImplementedError()
+
+    @property
+    def is_64bit(self) -> bool:
+        """
+        ``True`` if the target process is 64-bit, ``False`` if it is 32-bit.
+
+        Detected once on first access (a single syscall per backend — see
+        :meth:`_detect_is_64bit`) and cached for the lifetime of this object.
+        A process never changes bitness, so the cached value stays valid.
+
+        This is what powers the automatic ``ptr_size`` default of
+        :meth:`resolve_pointer_chain`, :meth:`scan_pointer_paths`,
+        :meth:`get_pointer` and :class:`~PyMemoryEditor.RemotePointer`: leave
+        ``ptr_size`` as ``None`` and the right pointer width (4 or 8) is used.
+        """
+        if self._is_64bit_cache is None:
+            self._is_64bit_cache = bool(self._detect_is_64bit())
+        return self._is_64bit_cache
+
+    @property
+    def pointer_size(self) -> int:
+        """
+        Pointer width of the target process in bytes — ``8`` for a 64-bit
+        target, ``4`` for a 32-bit one. Derived from :attr:`is_64bit`.
+
+        Use it as the explicit ``ptr_size`` for the pointer APIs, or simply
+        leave ``ptr_size=None`` (the default) to let them read this value.
+        """
+        return 8 if self.is_64bit else 4
 
     @abstractmethod
     def close(self) -> bool:
@@ -367,7 +417,7 @@ class AbstractProcess(ABC):
         *,
         pytype: Type = int,
         bufflength: Optional[int] = None,
-        ptr_size: int = 8,
+        ptr_size: Optional[int] = None,
     ) -> "RemotePointer":
         """
         Build a :class:`~PyMemoryEditor.RemotePointer` bound to this process —
@@ -376,7 +426,8 @@ class AbstractProcess(ABC):
         Convenience wrapper around the ``RemotePointer(self, ...)`` constructor;
         see that class for the meaning of every parameter (notably ``offsets``,
         whose ``None`` vs ``[]`` distinction selects a direct handle vs a
-        single-dereference chain).
+        single-dereference chain). Leaving ``ptr_size=None`` lets the pointer
+        adopt the target's :attr:`pointer_size` automatically.
 
         Example
         -------
@@ -401,7 +452,7 @@ class AbstractProcess(ABC):
         base_address: int,
         offsets: Sequence[int],
         *,
-        ptr_size: int = 8,
+        ptr_size: Optional[int] = None,
     ) -> int:
         """
         Walk a multi-level pointer chain — the kind of recipe Cheat Engine
@@ -418,8 +469,9 @@ class AbstractProcess(ABC):
             ``module_base + static_offset``.
         :param offsets: sequence of offsets to walk. Pass ``[]`` to dereference
             ``base_address`` once and return that pointer.
-        :param ptr_size: pointer width — 8 for 64-bit targets (default), 4 for
-            32-bit targets.
+        :param ptr_size: pointer width — 8 for 64-bit targets, 4 for 32-bit.
+            Leave ``None`` (the default) to use the target's
+            :attr:`pointer_size`, detected automatically.
 
         Example
         -------
@@ -432,6 +484,9 @@ class AbstractProcess(ABC):
             hp_addr = process.resolve_pointer_chain(0x14010F4F4, [0x0, 0x158])
             hp = process.read_process_memory(hp_addr, int, 4)
         """
+        if ptr_size is None:
+            ptr_size = self.pointer_size
+
         if ptr_size not in (4, 8):
             raise ValueError(
                 "ptr_size must be 4 (32-bit target) or 8 (64-bit target)."
@@ -491,7 +546,7 @@ class AbstractProcess(ABC):
         *,
         max_depth: int = 5,
         max_offset: int = 0x400,
-        ptr_size: int = 8,
+        ptr_size: Optional[int] = None,
         aligned: bool = True,
         writable_only: bool = True,
         static_ranges: Optional[Sequence[Tuple[int, int]]] = None,
@@ -521,8 +576,9 @@ class AbstractProcess(ABC):
         :param max_offset: largest positive offset a single hop may add (the
             struct-size window). Larger values catch fields deeper inside
             objects at the cost of many more candidate paths.
-        :param ptr_size: pointer width — 8 for 64-bit targets (default), 4 for
-            32-bit.
+        :param ptr_size: pointer width — 8 for 64-bit targets, 4 for 32-bit.
+            Leave ``None`` (the default) to use the target's
+            :attr:`pointer_size`, detected automatically.
         :param aligned: only consider pointers at natural alignment (default,
             much faster). Set ``False`` to also scan misaligned slots (slow).
         :param writable_only: build the pointer map from writable memory only
@@ -561,6 +617,9 @@ class AbstractProcess(ABC):
             build_pointer_map,
             find_pointer_paths,
         )
+
+        if ptr_size is None:
+            ptr_size = self.pointer_size
 
         if ptr_size not in (4, 8):
             raise ValueError(

--- a/PyMemoryEditor/process/remote_pointer.py
+++ b/PyMemoryEditor/process/remote_pointer.py
@@ -56,7 +56,9 @@ class RemotePointer:
         (defaults: int→4, float→8, bool→1); ``str`` and ``bytes`` require an
         explicit size.
     :param ptr_size: pointer width used when walking ``offsets`` — 8 for 64-bit
-        targets (default), 4 for 32-bit. Ignored for a direct handle.
+        targets, 4 for 32-bit. Leave ``None`` (the default) to use the target
+        process's :attr:`~PyMemoryEditor.process.abstract.AbstractProcess.pointer_size`,
+        detected automatically. Ignored for a direct handle.
 
     Example
     -------
@@ -78,7 +80,7 @@ class RemotePointer:
         *,
         pytype: Type = int,
         bufflength: Optional[int] = None,
-        ptr_size: int = 8,
+        ptr_size: Optional[int] = None,
     ):
         self._process = process
         self._base_address = base_address

--- a/PyMemoryEditor/win32/functions.py
+++ b/PyMemoryEditor/win32/functions.py
@@ -102,6 +102,13 @@ kernel32.VirtualQueryEx.restype = ctypes.c_size_t
 kernel32.GetSystemInfo.argtypes = (ctypes.POINTER(SYSTEM_INFO),)
 kernel32.GetSystemInfo.restype = None
 
+# void GetNativeSystemInfo(LPSYSTEM_INFO lpSystemInfo);
+# Unlike GetSystemInfo, this reports the *native* architecture even when the
+# caller is a 32-bit (WOW64) process — so it tells us the true OS bitness
+# regardless of how Python itself was built.
+kernel32.GetNativeSystemInfo.argtypes = (ctypes.POINTER(SYSTEM_INFO),)
+kernel32.GetNativeSystemInfo.restype = None
+
 # BOOL IsWow64Process(HANDLE hProcess, PBOOL Wow64Process);
 # True when the target is a 32-bit process running on 64-bit Windows.
 kernel32.IsWow64Process.argtypes = (
@@ -189,6 +196,19 @@ kernel32.GetSystemInfo(ctypes.byref(system_information))
 _HOST_IS_64BIT = ctypes.sizeof(ctypes.c_void_p) == 8
 
 
+# Native OS bitness, independent of how Python was built. GetNativeSystemInfo
+# reports the true architecture even from a 32-bit (WOW64) interpreter.
+_native_system_information = SYSTEM_INFO()
+kernel32.GetNativeSystemInfo(ctypes.byref(_native_system_information))
+
+# wProcessorArchitecture values that imply a 64-bit OS: AMD64 (9), ARM64 (12),
+# IA64 (6). Anything else (notably INTEL = 0) means a 32-bit OS.
+_PROCESSOR_ARCHITECTURE_64BIT = (6, 9, 12)
+_OS_IS_64BIT = (
+    _native_system_information.wProcessorArchitecture in _PROCESSOR_ARCHITECTURE_64BIT
+)
+
+
 def mbi_class_for_handle(process_handle: int):
     """
     Return the appropriate MEMORY_BASIC_INFORMATION layout for the target process.
@@ -210,6 +230,28 @@ def mbi_class_for_handle(process_handle: int):
     return (
         MEMORY_BASIC_INFORMATION_32 if is_wow64.value else MEMORY_BASIC_INFORMATION_64
     )
+
+
+def IsProcess64Bit(process_handle: int) -> bool:
+    """
+    Return ``True`` if the target process is 64-bit, ``False`` if 32-bit.
+
+    On a 32-bit OS every process is 32-bit. On a 64-bit OS a process is 32-bit
+    exactly when it runs under WOW64 (``IsWow64Process`` returns True); a
+    native (non-WOW64) process is 64-bit. The OS bitness is taken from
+    ``GetNativeSystemInfo`` so the answer is correct even from a 32-bit Python.
+    """
+    if not _OS_IS_64BIT:
+        return False
+
+    is_wow64 = ctypes.wintypes.BOOL(0)
+    ok = kernel32.IsWow64Process(process_handle, ctypes.byref(is_wow64))
+    if not ok:
+        # Couldn't query — fall back to the OS bitness (the most likely answer
+        # on a 64-bit host) rather than raise from a simple property access.
+        return True
+
+    return not bool(is_wow64.value)
 
 
 T = TypeVar("T")

--- a/PyMemoryEditor/win32/process.py
+++ b/PyMemoryEditor/win32/process.py
@@ -21,6 +21,7 @@ from .functions import (
     GetModules,
     GetProcessHandle,
     GetThreads,
+    IsProcess64Bit,
     ReadProcessMemory,
     SearchAddressesByPattern,
     SearchAddressesByValue,
@@ -170,6 +171,10 @@ class WindowsProcess(AbstractProcess):
                 raise ctypes.WinError(last_error, "CloseHandle failed.")
             raise OSError("CloseHandle failed.")
         return True
+
+    def _detect_is_64bit(self) -> bool:
+        self.__require_open()
+        return IsProcess64Bit(self.__process_handle)
 
     def get_memory_regions(self) -> Generator[dict, None, None]:
         self.__require_open()

--- a/tests/test_bitness.py
+++ b/tests/test_bitness.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+
+"""
+Tests for the bitness/architecture detection exposed by every backend:
+``AbstractProcess.is_64bit`` / ``AbstractProcess.pointer_size`` and the
+automatic ``ptr_size`` default it powers on the pointer APIs.
+
+Opened against the test's own process, so ``is_64bit`` must agree with the
+running interpreter's pointer width on all three platforms.
+"""
+
+import ctypes
+import os
+import sys
+
+import pytest
+
+if sys.platform not in ("win32", "darwin") and not sys.platform.startswith("linux"):
+    pytest.skip("Platform not supported by PyMemoryEditor", allow_module_level=True)
+
+
+from PyMemoryEditor import OpenProcess  # noqa: E402
+
+
+HOST_IS_64BIT = ctypes.sizeof(ctypes.c_void_p) == 8
+
+
+@pytest.fixture
+def process():
+    handle = OpenProcess(pid=os.getpid())
+    try:
+        yield handle
+    finally:
+        handle.close()
+
+
+def test_is_64bit_matches_host(process):
+    """Detection must agree with the interpreter we're running under."""
+    assert process.is_64bit is HOST_IS_64BIT
+
+
+def test_pointer_size_follows_is_64bit(process):
+    """pointer_size is 8 for a 64-bit target, 4 for a 32-bit one."""
+    assert process.pointer_size == (8 if process.is_64bit else 4)
+    assert process.pointer_size == ctypes.sizeof(ctypes.c_void_p)
+
+
+def test_is_64bit_is_cached(process):
+    """The result is detected once and reused (no re-querying the OS)."""
+    assert process._is_64bit_cache is None  # not yet detected
+    first = process.is_64bit
+    assert process._is_64bit_cache is first  # cached after first access
+    assert process.is_64bit is first
+
+
+def test_resolve_pointer_chain_uses_detected_ptr_size(process):
+    """
+    With ``ptr_size`` left as None, resolve_pointer_chain must read pointers at
+    the target's native width — proven by recovering a planted address.
+    """
+    target = ctypes.c_int(0x1234ABCD)
+    holder = ctypes.c_void_p(ctypes.addressof(target))
+
+    resolved = process.resolve_pointer_chain(ctypes.addressof(holder), [])
+
+    assert resolved == ctypes.addressof(target)
+
+
+def test_remote_pointer_defaults_to_detected_ptr_size(process):
+    """A RemotePointer built without ptr_size walks chains at pointer_size."""
+    target = ctypes.c_int(0x0BADF00D)
+    holder = ctypes.c_void_p(ctypes.addressof(target))
+
+    pointer = process.get_pointer(ctypes.addressof(holder), [], pytype=int, bufflength=4)
+
+    assert pointer.address == ctypes.addressof(target)
+    assert (pointer.value & 0xFFFFFFFF) == 0x0BADF00D


### PR DESCRIPTION
## Summary

Adds automatic process-bitness detection and uses it as the default pointer width across the pointer APIs, so callers no longer have to pass `ptr_size` by hand (and can't get it wrong for the target).

### New public surface
- **`process.is_64bit`** — `True`/`False`, detected once and cached for the process lifetime.
- **`process.pointer_size`** — `8` for a 64-bit target, `4` for a 32-bit one.

### Automatic `ptr_size`
`resolve_pointer_chain`, `scan_pointer_paths`, `get_pointer` and `RemotePointer` now accept `ptr_size=None` (the new default). The `None` is resolved **lazily** — only when an address is actually walked — to `pointer_size`, so building a pointer costs no syscall and repeated reads detect only once. Passing an explicit `4`/`8` keeps working exactly as before.

### Detection per platform
| Platform | Source |
|---|---|
| Windows | `IsWow64Process`, gated by `GetNativeSystemInfo` (true OS bitness, correct even from a 32-bit interpreter) |
| Linux | `EI_CLASS` byte of the ELF header from `/proc/<pid>/exe`, with a file-backed executable-mapping fallback |
| macOS | Mach-O header magic (`MH_MAGIC_64` vs `MH_MAGIC`) |

## Tests
- New `tests/test_bitness.py` (5 tests): detection matches the host, `pointer_size` follows `is_64bit`, the result is cached, and the pointer APIs adopt the detected width when `ptr_size` is omitted.
- Existing pointer/scan suites pass unchanged (`test_pointer_chain`, `test_remote_pointer`, `test_pointer_scan`, `test_scan`, `test_module_enumeration`).

## Backward compatibility
Fully backward compatible — the only signature change is `ptr_size`'s default going from `8` to `None`, which resolves to `8` on 64-bit targets (the previous behavior) and to `4` on 32-bit ones.