### PR TITLE
feat: lower default pointer-scan depth to 3 and relocate count label

### DIFF
--- a/PyMemoryEditor/app/pointer_scan_dialog.py
+++ b/PyMemoryEditor/app/pointer_scan_dialog.py
@@ -369,7 +369,7 @@ class PointerScanDialog(QDialog):
 
         self._depth_spin = QSpinBox()
         self._depth_spin.setRange(1, 12)
-        self._depth_spin.setValue(5)
+        self._depth_spin.setValue(3)
         self._depth_spin.setToolTip(
             "Maximum pointer levels (offsets) in a chain. Deeper finds more "
             "paths but costs exponentially more time."
@@ -487,16 +487,16 @@ class PointerScanDialog(QDialog):
 
         button_row.addStretch(1)
 
-        self._count_label = QLabel("")
-        self._count_label.setObjectName("hint")
-        button_row.addWidget(self._count_label)
-
         close_btn = QPushButton("Close")
         close_btn.setStyleSheet(_equal_height)
         close_btn.clicked.connect(self.accept)
         button_row.addWidget(close_btn)
 
         layout.addLayout(button_row)
+
+        self._count_label = QLabel("")
+        self._count_label.setObjectName("hint")
+        layout.addWidget(self._count_label)
 
         self._progress = QProgressBar()
         self._progress.setRange(0, 100)

--- a/PyMemoryEditor/process/abstract.py
+++ b/PyMemoryEditor/process/abstract.py
@@ -776,7 +776,7 @@ class AbstractProcess(ABC):
         self,
         target_address: int,
         *,
-        max_depth: int = 5,
+        max_depth: int = 3,
         max_offset: int = 0x400,
         ptr_size: Optional[int] = None,
         aligned: bool = True,
@@ -836,7 +836,7 @@ class AbstractProcess(ABC):
         ::
 
             hp_addr = next(process.search_by_value(int, 4, 1234))
-            for path in process.scan_pointer_paths(hp_addr, max_depth=5, max_results=20):
+            for path in process.scan_pointer_paths(hp_addr, max_depth=3, max_results=20):
                 print(path)                 # "game.exe"+0x10F4F4 -> [+0x0] -> +0x158
                 assert path.resolve(process) == hp_addr
 

--- a/PyMemoryEditor/process/pointer_scan.py
+++ b/PyMemoryEditor/process/pointer_scan.py
@@ -346,7 +346,7 @@ def find_pointer_paths(
     is_static: Callable[[int], bool],
     module_resolver: Callable[[int], Optional[Tuple[str, int]]],
     *,
-    max_depth: int = 5,
+    max_depth: int = 3,
     max_offset: int = 0x400,
     ptr_size: int = 8,
     max_results: Optional[int] = None,


### PR DESCRIPTION
## Summary

- Lower the default `max_depth` from `5` to `3` across the pointer-scan API (`find_pointer_paths`), the abstract process (`scan_pointer_paths`), and the dialog's depth spin box. Shallower scans are dramatically faster and cover the common case; users can still raise the depth when needed.
- Move the result count label out of the action button row onto its own row below the buttons, so it no longer competes for horizontal space with the Scan/Stop/Rescan/Intersect/Export/Close buttons.

## Test plan

- Open the pointer-scan dialog and confirm the count label renders below the button row.
- Run a scan and confirm the default depth is 3 and the count label updates correctly.