### PR TITLE
fix: unlock scanner controls when switching to a new process

### DIFF
--- a/PyMemoryEditor/app/main_window.py
+++ b/PyMemoryEditor/app/main_window.py
@@ -796,6 +796,10 @@ class MainWindow(QMainWindow):
         self._region_snapshot = None
         self._results_model.clear()
         self._scanner.set_has_results(False)
+        # If the previous target exited, _check_process_alive locked the scanner
+        # via set_busy(True). Switching to a live process must release that lock,
+        # otherwise the scan controls stay disabled against the new target.
+        self._scanner.set_busy(False)
 
         # Tear down auxiliary dialogs that hold a reference to the old
         # process — reopening them rebuilds against the new target.


### PR DESCRIPTION
## Problem

When the target process exits, `_check_process_alive` disables the scanner controls by calling `set_busy(True)` ("operations disabled"). Switching to a new live process via **File → Change Process…** updated the badge, cleared results, and rebuilt the cheat table — but never reset the busy flag. As a result, the scan controls stayed disabled against the new target.

## Fix

Reset `self._scanner.set_busy(False)` in `_change_process`, alongside the existing results/snapshot reset, so the scan controls re-enable for the new process.

This also covers the general case: every process switch now guarantees an unlocked state.