### PR TITLE
ci: auto-label PRs by changed files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -21,7 +21,7 @@ win32:
       - any-glob-to-any-file:
           - "PyMemoryEditor/win32/**"
 
-macos:
+macOS:
   - changed-files:
       - any-glob-to-any-file:
           - "PyMemoryEditor/macos/**"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,38 @@
+# Path-based labels applied to PRs by .github/workflows/labeler.yml.
+# Uses actions/labeler@v5 match rules.
+
+docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+
+app:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "PyMemoryEditor/app/**"
+
+linux:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "PyMemoryEditor/linux/**"
+
+win32:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "PyMemoryEditor/win32/**"
+
+macos:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "PyMemoryEditor/macos/**"
+
+# Any change inside the PyMemoryEditor package.
+lib:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "PyMemoryEditor/**"
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "tests/**"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,27 @@
+name: Labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Label PR by changed files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels
+        uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: true


### PR DESCRIPTION
## Summary

Adds automatic PR labeling based on which files a pull request touches.

- **`.github/workflows/labeler.yml`** — runs `actions/labeler@v5` on PRs (`opened`, `synchronize`, `reopened`). Uses `pull_request_target` (consistent with `lint-pr-title.yml`) so it also covers fork PRs, with `sync-labels: true` to drop labels when matching files leave the diff.
- **`.github/labeler.yml`** — the path→label rules.

This also makes real the reference to `.github/workflows/labeler.yml` already present in `lint-pr-title.yml`.

## Label rules

| Label | Matches |
|-------|---------|
| `docs` | `docs/**` |
| `app` | `PyMemoryEditor/app/**` |
| `linux` | `PyMemoryEditor/linux/**` |
| `win32` | `PyMemoryEditor/win32/**` |
| `macos` | `PyMemoryEditor/macos/**` |
| `lib` | `PyMemoryEditor/**` (any change in the package) |
| `tests` | `tests/**` |

Since `lib` matches all of `PyMemoryEditor/**`, a backend change (e.g. `PyMemoryEditor/linux/`) gets both its specific label and `lib`, as intended.

The seven labels were created in the repo with distinct colors.