### PR TITLE
ci: run the test matrix on macOS as well

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -70,6 +70,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
+          - macos-latest
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
## Summary

Adds `macos-latest` to the `build` job matrix so the test suite runs on macOS alongside Linux and Windows, across all supported Python versions (3.10–3.13).

## Notes

- The "Install Qt system libraries (Linux)" step stays gated on `runner.os == 'Linux'`, so macOS skips it — the GitHub macOS runners already ship what PySide6 needs.
- The end-to-end tests open the current process (`OpenProcess(pid=os.getpid())`), which on macOS uses `mach_task_self_` directly — no `task_for_pid`, debugger entitlement, or root required.