### PR TITLE
fix: exclude the dyld shared cache from macOS value scans

### DIFF
--- a/PyMemoryEditor/macos/functions.py
+++ b/PyMemoryEditor/macos/functions.py
@@ -43,17 +43,21 @@ from .types import (
     TASK_DYLD_INFO,
     TASK_DYLD_INFO_COUNT,
     VM_FLAGS_ANYWHERE,
+    VM_MEMORY_SHARED_PMAP,
     VM_PROT_COPY,
     VM_PROT_READ,
     VM_PROT_WRITE,
     VM_REGION_BASIC_INFO_64,
     VM_REGION_BASIC_INFO_COUNT_64,
+    VM_REGION_EXTENDED_INFO,
+    VM_REGION_EXTENDED_INFO_COUNT,
     mach_msg_type_number_t,
     mach_port_t,
     mach_vm_address_t,
     mach_vm_size_t,
     task_dyld_info_data_t,
     vm_region_basic_info_64,
+    vm_region_extended_info,
 )
 
 
@@ -119,6 +123,53 @@ def release_task(task: int) -> None:
         libsystem.mach_port_deallocate(mach_task_self_.value, task)
 
 
+def _region_user_tag(task: int, address: int) -> int:
+    """Return the ``vm_region_extended_info.user_tag`` for the region at ``address``.
+
+    A second, extended-info ``mach_vm_region`` query (the enumeration uses
+    basic info, which has no ``user_tag``). Returns 0 — an unassigned tag — on
+    any failure, so callers treat an unknown region as "not the shared cache".
+    """
+    addr = mach_vm_address_t(address)
+    size = mach_vm_size_t(0)
+    info = vm_region_extended_info()
+    info_count = mach_msg_type_number_t(VM_REGION_EXTENDED_INFO_COUNT)
+    object_name = mach_port_t(0)
+
+    kr = libsystem.mach_vm_region(
+        task,
+        ctypes.byref(addr),
+        ctypes.byref(size),
+        VM_REGION_EXTENDED_INFO,
+        ctypes.cast(ctypes.byref(info), ctypes.c_void_p),
+        ctypes.byref(info_count),
+        ctypes.byref(object_name),
+    )
+
+    if kr != KERN_SUCCESS:
+        return 0
+    if object_name.value:
+        libsystem.mach_port_deallocate(mach_task_self_.value, object_name.value)
+    return info.user_tag
+
+
+def _region_is_shared(task: int, address: int, basic_shared: int) -> bool:
+    """Whether the region is a shared/file-backed mapping value scans should skip.
+
+    The basic-info ``shared`` flag is honored when set, but it reports FALSE for
+    the dyld shared cache — the multi-GB read-only library blob the kernel maps
+    into every process through a shared submap (tagged
+    :data:`VM_MEMORY_SHARED_PMAP`). Recognizing it here lets
+    :func:`default_scan_filter` exclude it, so a default value/pattern scan walks
+    only the target's own ~1 GB of private memory instead of ~6 GB — matching
+    the Linux/Win32 exclusion of file-backed library mappings and keeping macOS
+    scans (and the test suite) from running 4-6x slower than the other OSes.
+    """
+    if basic_shared:
+        return True
+    return _region_user_tag(task, address) == VM_MEMORY_SHARED_PMAP
+
+
 def get_memory_regions(task: int) -> Generator[MemoryRegion, None, None]:
     """
     Yield {address, size, struct} dicts describing each memory region of the task.
@@ -143,7 +194,7 @@ def get_memory_regions(task: int) -> Generator[MemoryRegion, None, None]:
             ctypes.byref(address),
             ctypes.byref(size),
             VM_REGION_BASIC_INFO_64,
-            ctypes.byref(info),
+            ctypes.cast(ctypes.byref(info), ctypes.c_void_p),
             ctypes.byref(info_count),
             ctypes.byref(object_name),
         )
@@ -168,7 +219,7 @@ def get_memory_regions(task: int) -> Generator[MemoryRegion, None, None]:
             size.value,
             info.protection,
             info.max_protection,
-            info.shared,
+            _region_is_shared(task, address.value, info.shared),
             info.reserved,
         )
 
@@ -357,7 +408,7 @@ def _query_region(task: int, address: int):
         ctypes.byref(addr),
         ctypes.byref(size),
         VM_REGION_BASIC_INFO_64,
-        ctypes.byref(info),
+        ctypes.cast(ctypes.byref(info), ctypes.c_void_p),
         ctypes.byref(info_count),
         ctypes.byref(object_name),
     )
@@ -381,7 +432,7 @@ def _query_region(task: int, address: int):
             size.value,
             info.protection,
             info.max_protection,
-            info.shared,
+            _region_is_shared(task, addr.value, info.shared),
             info.reserved,
         ),
     )

--- a/PyMemoryEditor/macos/libsystem.py
+++ b/PyMemoryEditor/macos/libsystem.py
@@ -24,7 +24,6 @@ from .types import (
     mach_vm_size_t,
     task_t,
     vm_map_t,
-    vm_region_basic_info_64,
 )
 
 
@@ -82,7 +81,10 @@ libsystem.mach_vm_region.argtypes = (
     POINTER(mach_vm_address_t),
     POINTER(mach_vm_size_t),
     ctypes.c_int,
-    POINTER(vm_region_basic_info_64),
+    # `vm_region_info_t` is a generic `int *` the caller sizes via `flavor` —
+    # declare it as an opaque pointer so both vm_region_basic_info_64 and
+    # vm_region_extended_info can be passed (each via ctypes.cast(byref, ...)).
+    ctypes.c_void_p,
     POINTER(mach_msg_type_number_t),
     POINTER(mach_port_t),
 )

--- a/PyMemoryEditor/macos/types.py
+++ b/PyMemoryEditor/macos/types.py
@@ -10,7 +10,7 @@ References:
 - mach/kern_return.h
 """
 
-from ctypes import Structure, c_int, c_uint, c_uint64, c_ushort, sizeof
+from ctypes import Structure, c_int, c_ubyte, c_uint, c_uint64, c_ushort, sizeof
 
 
 # `info_count` in mach_vm_region is measured in mach_msg_type_number_t units
@@ -33,6 +33,17 @@ memory_object_offset_t = c_uint64
 
 # Region info flavors
 VM_REGION_BASIC_INFO_64 = 9
+VM_REGION_EXTENDED_INFO = 13
+
+# user_tag (from vm_region_extended_info) of the dyld shared cache regions —
+# the read-only library text/data blob the kernel maps into *every* process
+# via a shared submap. On this machine it totals ~5.8 GB across three regions.
+# Crucially, the basic-info `shared` flag reports FALSE for these regions, so
+# without recognizing the tag a default value scan walks all ~6 GB of library
+# memory — making macOS scans (and the test suite) 4-6x slower than Linux/Win32,
+# which exclude the equivalent file-backed/shared mappings. See VM_MEMORY_*
+# constants in <mach/vm_statistics.h>.
+VM_MEMORY_SHARED_PMAP = 32
 
 # task_info() flavor that returns dyld's image-list pointer (mach/task_info.h).
 TASK_DYLD_INFO = 17
@@ -74,6 +85,34 @@ class vm_region_basic_info_64(Structure):
 # Number of mach_msg_type_number_t units in vm_region_basic_info_64.
 # Used as the in/out `info_count` parameter to mach_vm_region.
 VM_REGION_BASIC_INFO_COUNT_64 = sizeof(vm_region_basic_info_64) // _NATURAL_T_SIZE
+
+
+class vm_region_extended_info(Structure):
+    """Layout of struct vm_region_extended_info_data_t from <mach/vm_region.h>.
+
+    Only ``user_tag`` is consumed today (to recognize the dyld shared cache —
+    see :data:`VM_MEMORY_SHARED_PMAP`); the remaining fields are declared so the
+    struct size — and therefore :data:`VM_REGION_EXTENDED_INFO_COUNT` — matches
+    what the kernel expects.
+    """
+
+    _fields_ = [
+        ("protection", vm_prot_t),
+        ("user_tag", c_uint),
+        ("pages_resident", c_uint),
+        ("pages_shared_now_private", c_uint),
+        ("pages_swapped_out", c_uint),
+        ("pages_dirtied", c_uint),
+        ("ref_count", c_uint),
+        ("shadow_depth", c_ushort),
+        ("external_pager", c_ubyte),
+        ("share_mode", c_ubyte),
+        ("pages_reusable", c_uint),
+    ]
+
+
+# Number of mach_msg_type_number_t units in vm_region_extended_info.
+VM_REGION_EXTENDED_INFO_COUNT = sizeof(vm_region_extended_info) // _NATURAL_T_SIZE
 
 
 class task_dyld_info_data_t(Structure):

--- a/tests/test_macos_protect.py
+++ b/tests/test_macos_protect.py
@@ -20,6 +20,7 @@ if sys.platform != "darwin":
 from ctypes.util import find_library  # noqa: E402
 
 from PyMemoryEditor import OpenProcess  # noqa: E402
+from PyMemoryEditor.process.region import default_scan_filter  # noqa: E402
 
 
 # Page size on macOS arm64 is 16 KB; x86_64 is 4 KB. mmap will pick the right one.
@@ -66,6 +67,41 @@ def _mmap_readonly(size: int) -> int:
         raise OSError("mprotect failed")
 
     return addr
+
+
+def test_dyld_shared_cache_excluded_from_value_scans():
+    """The dyld shared cache must be flagged shared so value scans skip it.
+
+    macOS maps the read-only library blob (the dyld shared cache, ~6 GB) into
+    every process. Its ``vm_region_basic_info`` ``shared`` flag is FALSE, so
+    before the ``VM_MEMORY_SHARED_PMAP`` user_tag fix a default scan walked all
+    ~6 GB of it — making macOS scans (and this suite) 4-6x slower than the
+    other OSes, which exclude their equivalent file-backed library mappings.
+
+    Regression guard: there is at least one large readable region flagged
+    ``is_shared``, and ``default_scan_filter`` drops enough that the scanned set
+    is a small fraction of all readable memory.
+    """
+    process = OpenProcess(pid=os.getpid())
+    try:
+        regions = list(process.get_memory_regions())
+    finally:
+        process.close()
+
+    readable = [r for r in regions if r.is_readable]
+    readable_bytes = sum(r.size for r in readable)
+    scanned_bytes = sum(r.size for r in readable if default_scan_filter(r))
+
+    # The dyld shared cache shows up as one or more large readable regions that
+    # must now be classified as shared (256 MB is well below its real size).
+    big_shared = [
+        r for r in readable if r.is_shared and r.size >= 256 * 1024 * 1024
+    ]
+    assert big_shared, "dyld shared cache not recognized as a shared mapping"
+
+    # With the cache excluded the scanned set is a small slice of all readable
+    # memory — guards against a regression that scans the whole address space.
+    assert scanned_bytes < readable_bytes * 0.5
 
 
 def test_write_to_readonly_page_via_protect_flip():


### PR DESCRIPTION
## Problem

On macOS, every value/pattern scan walked the **dyld shared cache** — the ~5.8 GB of read-only library text/data the kernel maps into *every* process. Linux and Windows already exclude their equivalent file-backed/shared library mappings via `default_scan_filter`, but on macOS the filter excluded **nothing**: it relies on `MemoryRegion.is_shared`, which on macOS reads the `shared` flag of `vm_region_basic_info_64` — and that flag reports **FALSE** for the shared cache.

Measured on a real process (current Python interpreter under pytest):

| | bytes a default scan walks |
|---|---|
| All readable regions | 6.59 GB |
| Marked `is_shared` (before) | **0 GB** |

So the pure-Python scan loop chewed through ~6.6 GB on macOS versus ~1 GB on the other platforms — making scans (and the CI test suite, which runs without the NumPy fast path) **4-6x slower**: ~15-25 min on macOS vs ~4-6 min on Linux/Windows.

The three offending regions (2176 / 2016 / 1632 MB here) all carry `vm_region_extended_info.user_tag == VM_MEMORY_SHARED_PMAP (32)` — the kernel's identifier for the shared-cache submap. The private heap regions we *do* want to scan carry malloc tags instead.

## Fix

Recognize the shared cache by its `user_tag` (read via a `VM_REGION_EXTENDED_INFO` query, since the basic-info struct has no tag) and mark those regions as `is_shared`, so `default_scan_filter` drops them — matching the Linux/Win32 exclusion of file-backed library mappings.

- `macos/types.py` — add the `vm_region_extended_info` struct + `VM_REGION_EXTENDED_INFO` / `VM_MEMORY_SHARED_PMAP` constants.
- `macos/libsystem.py` — generalize the `mach_vm_region` prototype (`info` as an opaque pointer) so both basic- and extended-info structs can be passed.
- `macos/functions.py` — `_region_user_tag()` reads the tag; `_region_is_shared()` returns the basic `shared` flag **OR** `user_tag == VM_MEMORY_SHARED_PMAP`. Used by `get_memory_regions` and `_query_region`.
- `tests/test_macos_protect.py` — regression test: the shared cache must be flagged `is_shared`, and `default_scan_filter` must exclude it.

**Pointer scans and address-list reads are unaffected** — they filter on `is_readable`/`is_writable`, not `is_shared`, so the shared cache is still a valid pointer target and a valid explicit-address read.

## Results

- Bytes scanned: **6.59 GB → 0.97 GB** (~6.7x)
- Real `search_by_value`: **11.94 s → 1.56 s** (7.6x)
- Full macOS suite: **~17 min → ~6 min** (parity with Linux/Windows)
- `346 passed, 13 skipped`; flake8 and mypy clean.