### PR TITLE
test: improve test params

### DIFF
--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -252,9 +252,9 @@ def test_search_by_int(process):
         except OSError:
             pass
 
-    assert found / test_length >= 0.7
+    assert found / test_length >= 0.8
     # Some addresses are beyond our control and may have their values changed.
-    assert correct / total >= 0.7
+    assert correct / total >= 0.5
 
 
 def test_search_by_float(process):
@@ -290,8 +290,8 @@ def test_search_by_float(process):
         except OSError:
             pass
 
-    assert found / test_length >= 0.7
-    assert correct / total >= 0.7
+    assert found / test_length >= 0.8
+    assert correct / total >= 0.5
 
 
 def test_search_by_string(process):
@@ -327,8 +327,8 @@ def test_search_by_string(process):
                 # it back, or hold non-decodable bytes. Either way, skip it.
                 pass
 
-    assert found / test_length >= 0.7
-    assert correct / total >= 0.7
+    assert found / test_length >= 0.8
+    assert correct / total >= 0.5
 
 
 def test_search_by_string_between(process):


### PR DESCRIPTION
**Why is this PR necessary, what does it do?**
This pull request updates the test assertions in `tests/test_editor.py` for the integer, float, and string search tests. The changes adjust the thresholds for what is considered a passing test, making the tests slightly stricter in terms of the number of found items, but more lenient in terms of correctness.

**Test assertion threshold adjustments:**

* Increased the minimum required ratio for `found / test_length` from 0.7 to 0.8 in the `test_search_by_int`, `test_search_by_float`, and `test_search_by_string` functions to make the tests stricter about finding enough items. [[1]](diffhunk://#diff-6819200e893d56f801fcfd3340f50bd929c68f8c1ee28f819ba7f5e4f2da42a9L255-R257) [[2]](diffhunk://#diff-6819200e893d56f801fcfd3340f50bd929c68f8c1ee28f819ba7f5e4f2da42a9L293-R294) [[3]](diffhunk://#diff-6819200e893d56f801fcfd3340f50bd929c68f8c1ee28f819ba7f5e4f2da42a9L330-R331)
* Decreased the minimum required ratio for `correct / total` from 0.7 to 0.5 in the same test functions, making the correctness requirement more lenient. [[1]](diffhunk://#diff-6819200e893d56f801fcfd3340f50bd929c68f8c1ee28f819ba7f5e4f2da42a9L255-R257) [[2]](diffhunk://#diff-6819200e893d56f801fcfd3340f50bd929c68f8c1ee28f819ba7f5e4f2da42a9L293-R294) [[3]](diffhunk://#diff-6819200e893d56f801fcfd3340f50bd929c68f8c1ee28f819ba7f5e4f2da42a9L330-R331)

**Checklist (complete all items)**:

- [x] Added tests as necessary.
- [x] There is no breaking change for existing features.

**References:**

<!-- (Nice to have) 
Link tasks, issues, PRs that are related to this pull request, etc. 
-->

No references to be shared. 

**Notes:**

<!-- (Optional) 
Explain some changes that can be useful when reviewing this pull request. 
-->

No notes to be shared. 