### PR TITLE
docs: add funding page

### DIFF
--- a/docs/funding.md
+++ b/docs/funding.md
@@ -1,0 +1,11 @@
+# Funding
+
+If PyMemoryEditor is useful to you, consider supporting the project:
+
+<iframe src="https://github.com/sponsors/JeanExtreme002/button" title="Sponsor JeanExtreme002" height="32" width="114" style="border: 0; border-radius: 6px;"></iframe>
+
+<br/>
+<br/>
+<br/>
+
+You can also help by [⭐ starring the repository](https://github.com/JeanExtreme002/PyMemoryEditor) or [contributing](contributing.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -136,9 +136,10 @@ used throughout these docs, plus how to contribute and the project's license.
 platform-notes
 troubleshooting
 guide/logging
-glossary
 contributing
+funding
 license
+glossary
 ```
 
 ## Project links


### PR DESCRIPTION
Add a funding/sponsorship page to the documentation and reorder the toctree entries for better navigation flow.