### PR TITLE
fix: fix documentation links in funding and glossary pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,9 @@ That's it — read, write or scan another process in three lines, the same way o
 
 ## What's inside
 
-<table>
-<tr>
-<td width="50%" valign="top">
+### 🐍 The Python library
 
-**🐍 The Python library**
+Full control over another process's memory — in a few lines of Python:
 
 - ✅ **Read & write** values (`int`, `float`, `bool`, `str`, `bytes`)
 - 🔍 **Value scan** with eight comparison modes
@@ -96,21 +94,15 @@ That's it — read, write or scan another process in three lines, the same way o
 - 🗺️ **Memory map**, **modules**, **threads**
 - 🧱 **Allocate & free** remote memory (Windows / macOS)
 
-</td>
-<td width="50%" valign="top">
+### 🖥️ The bundled GUI app
 
-**🖥️ The bundled GUI app**
-
-- 🎯 **Scanner** — every scan mode, ranges, regex/AOB search
-- 🔁 **Refine workflow** — First Scan → Next Scan…
-- 📋 **Cheat table** — freeze / write values, JSON import/export
-- 🔗 **Pointer scan** — export, rescan & compare
-- 🗺️ **Memory map** with R/W/X flags
-- 🔬 **Hex viewer** with write-back
-
-</td>
-</tr>
-</table>
+All the library's power — no code required:
+- ⚡ **Zero setup** — attach to a process and start scanning in seconds
+- 🧲 **Refine workflow** — First Scan → Next Scan with live visual feedback
+- 📋 **Cheat table** — freeze / write values on the fly, JSON import/export
+- 🔬 **Hex viewer** — browse raw memory and write back inline
+- 🧩 **Pointer scan UI** — scan, export & rescan across sessions with a few clicks
+- 🎨 **One-click access** — every feature at your fingertips, no code needed
 
 ---
 

--- a/docs/app.md
+++ b/docs/app.md
@@ -33,12 +33,7 @@ name or PID.
 
 ## What's inside
 
-<table class="inside-grid">
-<tr>
-<td width="50%" valign="top">
-
 **🎯 Scanner**
-
 - Every `ScanTypesEnum` mode
 - Int8 / Int16 / Int32 / Int64, Float / Double, Boolean, String (UTF-8) and
   Byte Array value types
@@ -49,46 +44,33 @@ name or PID.
   spans one byte (use `.+` for multibyte characters)
 
 **🔁 Refine workflow**
-
 - **First Scan → Next Scan** (Cheat Engine style)
 - Six Next Scan comparisons (increased / decreased / changed / unchanged, plus
   increased-by / decreased-by)
 - Live progress
 
 **📋 Cheat table**
-
 - Freeze / write values continuously
 - Per-entry custom labels
 - JSON import/export
 
-</td>
-<td width="50%" valign="top">
-
 **🔗 Pointer scan**
-
 - Same engine as `scan_pointer_paths`
 - Save scans to JSON
 - Rescan / compare scans to narrow them down
 - Send a resolved address straight to the Cheat Table
 
 **🗺️ Memory map**
-
 - All regions with R/W/X flags
 - Backing file path per region (Linux; blank where the OS doesn't expose it)
 
 **🔬 Hex viewer**
-
 - Live dump with write-back
 - Go to any address, with auto-refresh
 
 **🪵 Log console**
-
 - Same stream as `logging.getLogger("PyMemoryEditor")`
 - Pick the log level (DEBUG / INFO / WARNING / ERROR) at runtime
-
-</td>
-</tr>
-</table>
 
 ```{admonition} Cross-platform dark theme
 :class: tip

--- a/docs/funding.md
+++ b/docs/funding.md
@@ -1,6 +1,6 @@
 # Funding
 
-If PyMemoryEditor is useful to you, consider supporting the project:
+If PyMemoryEditor is useful to you, consider [supporting the project](https://github.com/sponsors/JeanExtreme002):
 
 <iframe src="https://github.com/sponsors/JeanExtreme002/button" title="Sponsor JeanExtreme002" height="32" width="114" style="border: 0; border-radius: 6px;"></iframe>
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -43,8 +43,8 @@ Memory region
 
 Module
    A file mapped into a process — the main executable plus every shared
-   library it loaded. PyMemoryEditor surfaces them as
-   :py:class:`ModuleInfo`.
+   library it loaded. PyMemoryEditor surfaces them as [`ModuleInfo`](api/module-info.md).
+
 
 Pointer chain
    A static base plus a series of offsets:


### PR DESCRIPTION
- Add hyperlink to sponsor page in funding docs
- Convert Sphinx cross-reference to Markdown link in glossary