### PR TITLE
feat: add Games/Entertainment topic classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Topic :: Games/Entertainment",
     "Topic :: Scientific/Engineering",
     "Topic :: Security",
     "Topic :: Software Development :: Debuggers",


### PR DESCRIPTION
Add the `Topic :: Games/Entertainment` trove classifier to pyproject.toml, since the library is commonly used for game memory editing.