### PR TITLE
fix: filter inaccessible regions from memory map total and simplify column header

### DIFF
--- a/PyMemoryEditor/app/memory_map_dialog.py
+++ b/PyMemoryEditor/app/memory_map_dialog.py
@@ -370,7 +370,10 @@ class MemoryMapDialog(AutoRefreshTableDialog):
         scroll_value = self._table.verticalScrollBar().value()
 
         total = len(self._snapshot)
-        total_bytes = sum(int(region.size) for region in self._snapshot)
+        total_bytes = sum(
+            int(region.size) for region in self._snapshot
+            if region.is_readable or region.is_writable or region.is_executable
+        )
 
         # Disable sorting while rebuilding so the model isn't re-sorted on every
         # appendRow (and rows don't shuffle mid-build).

--- a/PyMemoryEditor/app/memory_viewer_dialog.py
+++ b/PyMemoryEditor/app/memory_viewer_dialog.py
@@ -86,8 +86,14 @@ class MemoryViewerDialog(QDialog):
         self._size_spin.setSingleStep(16)
         top.addWidget(self._size_spin)
 
+        spin_h = self._size_spin.sizeHint().height()
+
         refresh_btn = QPushButton("Read")
         refresh_btn.setObjectName("secondary")
+        refresh_btn.setStyleSheet(
+            f"min-height: 0px; max-height: {spin_h}px; padding: 2px 14px;"
+        )
+        refresh_btn.setFixedHeight(spin_h)
         refresh_btn.clicked.connect(self.refresh)
         top.addWidget(refresh_btn)
         layout.addLayout(top)

--- a/PyMemoryEditor/app/open_process_dialog.py
+++ b/PyMemoryEditor/app/open_process_dialog.py
@@ -128,7 +128,7 @@ class _ProcessListWorker(QThread):
                     mem = _macos_phys_footprint(pid)
                 if mem < 0:
                     try:
-                        # RSS — physical memory in use. VMS on macOS is useless
+                        # RSS — physical memory in use. VMS is useless
                         # here: the kernel reserves huge virtual ranges for
                         # dyld/frameworks/malloc zones, so every process looks
                         # like 100s of GB.
@@ -219,7 +219,7 @@ class OpenProcessDialog(QDialog):
 
         self._model = QStandardItemModel(0, 4, self)
         self._model.setHorizontalHeaderLabels(
-            ["PID", "Process Name", "Memory (RSS)", "User"]
+            ["PID", "Process Name", "Memory", "User"]
         )
 
         self._proxy = _ProcessSortProxy(self)


### PR DESCRIPTION
- Filter total bytes in memory map to only sum regions that have at least one permission (readable, writable, or executable), excluding inaccessible regions from the total.
- Rename the process list column header from "Memory (RSS)" to "Memory".
- Generalize a comment about VMS being useless (not macOS-specific).