### PR TITLE
docs: update MemoryRegion.path docs to reflect cross-platform support

### DIFF
--- a/docs/api/memory-region.md
+++ b/docs/api/memory-region.md
@@ -63,8 +63,9 @@ of memory with its address, size, permissions and backing path.
       :type: str
 
       Best-effort path of the file backing the region, or ``""`` when
-      unknown. Linux exposes this directly from ``/proc/<pid>/maps``;
-      Windows and macOS would need extra syscalls and report ``""``.
+      unknown or anonymous. Linux reads it from ``/proc/<pid>/maps``;
+      Windows uses ``GetMappedFileNameW`` (NT device path); macOS uses
+      ``proc_regionfilename``.
 ```
 
 ## `MemoryRegionSnapshot`

--- a/docs/api/utilities.md
+++ b/docs/api/utilities.md
@@ -170,14 +170,18 @@ from PyMemoryEditor.process.region import (
 
 .. py:function:: region_path(struct)
 
-   Best-effort path of the file backing the region, or ``""`` when unknown
-   (Linux only — Windows/macOS would need extra syscalls).
+   Best-effort path of the file backing the region, or ``""`` when unknown.
+   Linux reads it from ``/proc/<pid>/maps``; Windows uses
+   ``GetMappedFileNameW`` (NT device path); macOS uses
+   ``proc_regionfilename``.
 
-.. py:function:: make_region(address, size, struct)
+.. py:function:: make_region(address, size, struct, *, path="")
 
    Build a fully-populated :py:class:`MemoryRegion` from a platform struct.
    The four boolean fields and ``path`` are computed once via the predicates
-   above. Backends call this once per region; user code rarely needs it.
+   above. When *path* is non-empty it overrides the struct-based
+   ``region_path()`` lookup. Backends call this once per region; user code
+   rarely needs it.
 ```
 
 ```{seealso}

--- a/docs/guide/memory-regions.md
+++ b/docs/guide/memory-regions.md
@@ -36,7 +36,7 @@ Each region is an instance of `MemoryRegion` — an immutable
 <tr><td><code>is_writable</code></td><td data-label="Type"><code>bool</code></td><td data-label="Meaning">True if the region can be written.</td></tr>
 <tr><td><code>is_executable</code></td><td data-label="Type"><code>bool</code></td><td data-label="Meaning">True if the region contains executable code.</td></tr>
 <tr><td><code>is_shared</code></td><td data-label="Type"><code>bool</code></td><td data-label="Meaning">True if the region is a shared/file-backed mapping.</td></tr>
-<tr><td><code>path</code></td><td data-label="Type"><code>str</code></td><td data-label="Meaning">Best-effort path of the file backing the region; populated on Linux (from <code>/proc/&lt;pid&gt;/maps</code>), <code>""</code> when unknown.</td></tr>
+<tr><td><code>path</code></td><td data-label="Type"><code>str</code></td><td data-label="Meaning">Best-effort path of the file backing the region. Linux reads it from <code>/proc/&lt;pid&gt;/maps</code>; Windows uses <code>GetMappedFileNameW</code> (NT device path); macOS uses <code>proc_regionfilename</code>. Empty string when unknown or anonymous.</td></tr>
 <tr><td><code>struct</code></td><td data-label="Type">platform-specific</td><td data-label="Meaning">Raw platform descriptor (see below).</td></tr>
 </table>
 


### PR DESCRIPTION
The `path` field documentation still described it as Linux-only (`""` on Windows/macOS), but #65 added `GetMappedFileNameW` (Windows) and `proc_regionfilename` (macOS) support.

### Changes

- **docs/api/memory-region.md** — updated `path` attribute description to list all three platform mechanisms.
- **docs/guide/memory-regions.md** — updated the field table to describe cross-platform path resolution.
- **docs/api/utilities.md** — updated `region_path()` docstring and added the `path` keyword argument to `make_region()` signature.