### PR TITLE
feat: add close button to Memory Viewer dialog

### DIFF
--- a/PyMemoryEditor/app/memory_viewer_dialog.py
+++ b/PyMemoryEditor/app/memory_viewer_dialog.py
@@ -117,6 +117,10 @@ class MemoryViewerDialog(QDialog):
         write_btn = QPushButton("Write Hex Below…")
         write_btn.clicked.connect(self._write_bytes)
         auto_row.addWidget(write_btn)
+
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(self.accept)
+        auto_row.addWidget(close_btn)
         layout.addLayout(auto_row)
 
         self._dump = QPlainTextEdit()


### PR DESCRIPTION
Adds a Close button to the Memory Viewer dialog toolbar, allowing users to dismiss the dialog without reaching for the window close button or pressing Escape.