### PR TITLE
ci: add workflow to publish to PyPI on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # Required for trusted publishing (OIDC)
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install build tools
+      run: python -m pip install --upgrade pip build
+
+    - name: Build package
+      run: python -m build
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically publishes the package to PyPI when a Release is created.

- Triggers on `release: published`
- Uses trusted publishing (OIDC) via `pypa/gh-action-pypi-publish` — no secrets needed
- Requires a one-time setup of a trusted publisher on PyPI (owner: `JeanExtreme002`, repo: `PyMemoryEditor`, workflow: `publish.yml`, environment: `pypi`)