### PR TITLE
fix(linux): preserve paths with whitespace in /proc/maps parsing

### DIFF
--- a/PyMemoryEditor/__init__.py
+++ b/PyMemoryEditor/__init__.py
@@ -8,7 +8,7 @@ Supported platforms: Windows, Linux and macOS (32-bit and 64-bit).
 """
 
 __author__ = "Jean Loui Bernard Silva de Jesus"
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 import logging
 import sys

--- a/PyMemoryEditor/linux/functions.py
+++ b/PyMemoryEditor/linux/functions.py
@@ -187,13 +187,13 @@ def get_memory_regions(pid: int) -> Generator["MemoryRegion", None, None]:
 
     with mapping_file:
         for line in mapping_file:
-            region_information = line.split()
+            region_information = line.split(maxsplit=5)
 
             try:
                 addressing_range, privileges, offset, device, inode = (
                     region_information[0:5]
                 )
-                path = region_information[5] if len(region_information) >= 6 else ""
+                path = region_information[5].strip() if len(region_information) >= 6 else ""
 
                 start_address, end_address = [
                     int(addr, 16) for addr in addressing_range.split("-")


### PR DESCRIPTION
Fixes #20

The `/proc/<pid>/maps` parser used `line.split()` without a limit, which broke pathnames containing whitespace (e.g. `/home/user/My Games/game.so`).

**Changes:**
- Use `line.split(maxsplit=5)` so the 6th field (pathname) remains intact regardless of spaces
- `.strip()` the path to remove the trailing newline that is now preserved by the limited split