### PR TITLE
chore: bump version to 2.1.0

### DIFF
--- a/PyMemoryEditor/__init__.py
+++ b/PyMemoryEditor/__init__.py
@@ -8,7 +8,7 @@ Supported platforms: Windows, Linux and macOS (32-bit and 64-bit).
 """
 
 __author__ = "Jean Loui Bernard Silva de Jesus"
-__version__ = "2.0.1"
+__version__ = "2.1.0"
 
 import logging
 import sys


### PR DESCRIPTION
Bumps `__version__` from `2.0.1` to `2.1.0`.

The last bump was in `9a0b41e` (tag `v2.0.1`). Since then, four commits landed on `main` without a version bump:

| Commit | Change |
|---|---|
| `4aef4c2` | feat: add `read_process_memory_into` for zero-copy buffer reuse (#71) (#72) |
| `041bfc0` | ci: remove macOS from the CI matrix |
| `a2c583b` | fix(app): prevent `OverflowError` from addresses above 2^63 in memory map (#77) |
| `b656c55` | fix(app): handle SIGINT so the app can close from a terminal (#78) |

`read_process_memory_into` is a new public API, so this is a minor bump rather than a patch.

`pyproject.toml` reads the version from `PyMemoryEditor/__init__.py` via `[tool.hatch.version]`, so no other file needs updating.