### PR TITLE
fix(app): stop the process-list refresh from stomping on scroll position and typed input

### DIFF
--- a/PyMemoryEditor/app/open_process_dialog.py
+++ b/PyMemoryEditor/app/open_process_dialog.py
@@ -173,6 +173,7 @@ class OpenProcessDialog(TearsDownOnClose, QDialog):
         super().__init__(parent)
         self.process: Optional[AbstractProcess] = None
         self._scan_worker: Optional[_ProcessListWorker] = None
+        self._restoring_selection = False
 
         self.setWindowTitle("Select a Process")
         self.setWindowIcon(app_icon())
@@ -327,7 +328,7 @@ class OpenProcessDialog(TearsDownOnClose, QDialog):
             for row in range(self._proxy.rowCount()):
                 idx = self._proxy.index(row, self.COL_PID)
                 if self._proxy.data(idx, Qt.UserRole) == selected_pid:
-                    self._table.selectRow(row)
+                    self._restore_selection(row)
                     break
 
         scrollbar.setValue(scroll_offset)
@@ -354,7 +355,25 @@ class OpenProcessDialog(TearsDownOnClose, QDialog):
     def _on_filter_changed(self, text: str) -> None:
         self._proxy.setFilterFixedString(text)
 
+    def _restore_selection(self, row: int) -> None:
+        """Re-select a row on the user's behalf, without echoing it into the entry.
+
+        ``_on_selection_changed`` mirrors the selected PID into the "Process:"
+        field, which is what a click should do and what a refresh tick must not:
+        a user who clicked a row and then typed a process name had their text
+        replaced by the old PID within 3 s, so pressing Enter opened the wrong
+        target.
+        """
+        self._restoring_selection = True
+        try:
+            self._table.selectRow(row)
+        finally:
+            self._restoring_selection = False
+
     def _on_selection_changed(self, *_args) -> None:
+        if self._restoring_selection:
+            return
+
         pid = self._selected_pid()
         if pid is not None:
             self._entry.setText(str(pid))

--- a/PyMemoryEditor/app/open_process_dialog.py
+++ b/PyMemoryEditor/app/open_process_dialog.py
@@ -298,12 +298,9 @@ class OpenProcessDialog(TearsDownOnClose, QDialog):
     def _on_rows_ready(self, rows) -> None:
         selected_pid = self._selected_pid()
 
-        # Restoring the selection below re-triggers Qt's scrollTo(current),
-        # which yanked the list back to the selected row on every refresh tick:
-        # once any row had been clicked, scrolling through a long process list
-        # was impossible (#75). Remember where the user was and put them back
-        # afterwards. Rebuilding the model itself is not the problem — Qt defers
-        # the scrollbar range update, so the offset survives it.
+        # Restoring the selection below re-triggers Qt's scrollTo(current), which
+        # jumped the list back to the selected row on every tick (#75). The
+        # rebuild is harmless on its own: Qt defers the scrollbar range update.
         scrollbar = self._table.verticalScrollBar()
         scroll_offset = scrollbar.value()
 
@@ -357,23 +354,18 @@ class OpenProcessDialog(TearsDownOnClose, QDialog):
     def _on_filter_changed(self, text: str) -> None:
         selected_pid = self._selected_pid()
 
-        # Filtering the selected row out of view doesn't clear the selection: Qt
-        # remaps it onto whatever row took that index, so the picker would point
-        # at a process the user never chose. Neither that remap nor the cleanup
-        # after it is a pick, so neither may reach the entry.
+        # Hiding the selected row doesn't clear the selection: Qt remaps it onto
+        # whatever row took that index, retargeting the picker silently.
         with self._programmatic_selection():
             self._proxy.setFilterFixedString(text)
             if selected_pid is not None and self._selected_pid() != selected_pid:
                 self._table.selectionModel().clearSelection()
 
     def _on_row_activated(self, index) -> None:
-        """Open the row that was double-clicked, whatever the entry holds.
+        """Open the double-clicked row, whatever the entry holds.
 
-        Clicking a row that is already selected emits no ``selectionChanged``
-        (the table is single-selection), so the entry can still hold a name the
-        user typed earlier. The double-click is the more specific instruction of
-        the two, so it wins — and goes through the entry, which keeps one open
-        path and shows what is being opened.
+        Clicking an already-selected row emits no ``selectionChanged``, so the
+        entry can still hold a name typed earlier.
         """
         pid = self._proxy.data(self._proxy.index(index.row(), self.COL_PID), Qt.UserRole)
         if pid is not None:
@@ -382,14 +374,7 @@ class OpenProcessDialog(TearsDownOnClose, QDialog):
 
     @contextmanager
     def _programmatic_selection(self) -> Iterator[None]:
-        """Mark a selection change the user didn't make.
-
-        ``_on_selection_changed`` mirrors the selected PID into the "Process:"
-        field, which is what a click should do and what a refresh tick or a
-        filter keystroke must not: a user who clicked a row and then typed a
-        process name had their text replaced by a PID, so pressing Enter opened
-        the wrong target.
-        """
+        """Mark a selection change the user didn't make, so it can't reach the entry."""
         self._selection_is_programmatic = True
         try:
             yield

--- a/PyMemoryEditor/app/open_process_dialog.py
+++ b/PyMemoryEditor/app/open_process_dialog.py
@@ -241,6 +241,7 @@ class OpenProcessDialog(TearsDownOnClose, QDialog):
         self._table.horizontalHeader().setSectionResizeMode(
             self.COL_NAME, QHeaderView.Stretch
         )
+        self._table.clicked.connect(self._point_entry_at)
         self._table.doubleClicked.connect(self._on_row_activated)
         self._table.selectionModel().selectionChanged.connect(
             self._on_selection_changed
@@ -361,15 +362,20 @@ class OpenProcessDialog(TearsDownOnClose, QDialog):
             if selected_pid is not None and self._selected_pid() != selected_pid:
                 self._table.selectionModel().clearSelection()
 
-    def _on_row_activated(self, index) -> None:
-        """Open the double-clicked row, whatever the entry holds.
+    def _point_entry_at(self, index) -> None:
+        """Aim the entry at a clicked row.
 
-        Clicking an already-selected row emits no ``selectionChanged``, so the
-        entry can still hold a name typed earlier.
+        ``selectionChanged`` doesn't fire when the row was already selected, so
+        without this the entry keeps whatever it held — a name typed earlier, or
+        nothing — while the row sits highlighted as if it were the target.
         """
         pid = self._proxy.data(self._proxy.index(index.row(), self.COL_PID), Qt.UserRole)
         if pid is not None:
             self._entry.setText(str(pid))
+
+    def _on_row_activated(self, index) -> None:
+        """Open the double-clicked row, whatever the entry holds."""
+        self._point_entry_at(index)
         self._try_open()
 
     @contextmanager

--- a/PyMemoryEditor/app/open_process_dialog.py
+++ b/PyMemoryEditor/app/open_process_dialog.py
@@ -296,6 +296,15 @@ class OpenProcessDialog(TearsDownOnClose, QDialog):
     def _on_rows_ready(self, rows) -> None:
         selected_pid = self._selected_pid()
 
+        # Restoring the selection below re-triggers Qt's scrollTo(current),
+        # which yanked the list back to the selected row on every refresh tick:
+        # once any row had been clicked, scrolling through a long process list
+        # was impossible (#75). Remember where the user was and put them back
+        # afterwards. Rebuilding the model itself is not the problem — Qt defers
+        # the scrollbar range update, so the offset survives it.
+        scrollbar = self._table.verticalScrollBar()
+        scroll_offset = scrollbar.value()
+
         self._model.setRowCount(0)
         for pid, name, mem, user in rows:
             pid_item = NumericItem(str(pid))
@@ -320,6 +329,8 @@ class OpenProcessDialog(TearsDownOnClose, QDialog):
                 if self._proxy.data(idx, Qt.UserRole) == selected_pid:
                     self._table.selectRow(row)
                     break
+
+        scrollbar.setValue(scroll_offset)
 
     def _on_scan_finished(self, worker) -> None:
         """Retire the enumeration that just finished — and only that one.

--- a/PyMemoryEditor/app/open_process_dialog.py
+++ b/PyMemoryEditor/app/open_process_dialog.py
@@ -8,6 +8,7 @@ case-insensitive toggle, surfacing the library's ``case_sensitive`` flag).
 """
 import ctypes
 import sys
+from contextlib import contextmanager
 from typing import Callable, List, Optional, Tuple
 
 import psutil
@@ -173,7 +174,7 @@ class OpenProcessDialog(TearsDownOnClose, QDialog):
         super().__init__(parent)
         self.process: Optional[AbstractProcess] = None
         self._scan_worker: Optional[_ProcessListWorker] = None
-        self._restoring_selection = False
+        self._selection_is_programmatic = False
 
         self.setWindowTitle("Select a Process")
         self.setWindowIcon(app_icon())
@@ -240,7 +241,7 @@ class OpenProcessDialog(TearsDownOnClose, QDialog):
         self._table.horizontalHeader().setSectionResizeMode(
             self.COL_NAME, QHeaderView.Stretch
         )
-        self._table.doubleClicked.connect(lambda _i: self._try_open())
+        self._table.doubleClicked.connect(self._on_row_activated)
         self._table.selectionModel().selectionChanged.connect(
             self._on_selection_changed
         )
@@ -328,7 +329,8 @@ class OpenProcessDialog(TearsDownOnClose, QDialog):
             for row in range(self._proxy.rowCount()):
                 idx = self._proxy.index(row, self.COL_PID)
                 if self._proxy.data(idx, Qt.UserRole) == selected_pid:
-                    self._restore_selection(row)
+                    with self._programmatic_selection():
+                        self._table.selectRow(row)
                     break
 
         scrollbar.setValue(scroll_offset)
@@ -353,25 +355,49 @@ class OpenProcessDialog(TearsDownOnClose, QDialog):
         self._scan_worker = None
 
     def _on_filter_changed(self, text: str) -> None:
-        self._proxy.setFilterFixedString(text)
+        selected_pid = self._selected_pid()
 
-    def _restore_selection(self, row: int) -> None:
-        """Re-select a row on the user's behalf, without echoing it into the entry.
+        # Filtering the selected row out of view doesn't clear the selection: Qt
+        # remaps it onto whatever row took that index, so the picker would point
+        # at a process the user never chose. Neither that remap nor the cleanup
+        # after it is a pick, so neither may reach the entry.
+        with self._programmatic_selection():
+            self._proxy.setFilterFixedString(text)
+            if selected_pid is not None and self._selected_pid() != selected_pid:
+                self._table.selectionModel().clearSelection()
+
+    def _on_row_activated(self, index) -> None:
+        """Open the row that was double-clicked, whatever the entry holds.
+
+        Clicking a row that is already selected emits no ``selectionChanged``
+        (the table is single-selection), so the entry can still hold a name the
+        user typed earlier. The double-click is the more specific instruction of
+        the two, so it wins — and goes through the entry, which keeps one open
+        path and shows what is being opened.
+        """
+        pid = self._proxy.data(self._proxy.index(index.row(), self.COL_PID), Qt.UserRole)
+        if pid is not None:
+            self._entry.setText(str(pid))
+        self._try_open()
+
+    @contextmanager
+    def _programmatic_selection(self):
+        """Mark a selection change the user didn't make.
 
         ``_on_selection_changed`` mirrors the selected PID into the "Process:"
-        field, which is what a click should do and what a refresh tick must not:
-        a user who clicked a row and then typed a process name had their text
-        replaced by the old PID within 3 s, so pressing Enter opened the wrong
-        target.
+        field, which is what a click should do and what a refresh tick or a
+        filter keystroke must not: a user who clicked a row and then typed a
+        process name had their text replaced by a PID, so pressing Enter opened
+        the wrong target.
         """
-        self._restoring_selection = True
+        self._selection_is_programmatic = True
         try:
-            self._table.selectRow(row)
+            yield
         finally:
-            self._restoring_selection = False
+            self._selection_is_programmatic = False
 
     def _on_selection_changed(self, *_args) -> None:
-        if self._restoring_selection:
+        if self._selection_is_programmatic:
             return
 
         pid = self._selected_pid()

--- a/PyMemoryEditor/app/open_process_dialog.py
+++ b/PyMemoryEditor/app/open_process_dialog.py
@@ -9,7 +9,7 @@ case-insensitive toggle, surfacing the library's ``case_sensitive`` flag).
 import ctypes
 import sys
 from contextlib import contextmanager
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, Iterator, List, Optional, Tuple
 
 import psutil
 
@@ -381,7 +381,7 @@ class OpenProcessDialog(TearsDownOnClose, QDialog):
         self._try_open()
 
     @contextmanager
-    def _programmatic_selection(self):
+    def _programmatic_selection(self) -> Iterator[None]:
         """Mark a selection change the user didn't make.
 
         ``_on_selection_changed`` mirrors the selected PID into the "Process:"

--- a/tests/app/test_open_process_dialog.py
+++ b/tests/app/test_open_process_dialog.py
@@ -10,10 +10,14 @@ clicked any row, scrolling through the list snapped back to that row on every
 tick.
 
 The same tick also echoed the restored selection's PID into the "Process:" field,
-overwriting whatever the user had typed there.
+overwriting whatever the user had typed there. Typing in the Filter box did the
+same thing by a different route: hiding the selected row makes Qt remap the
+selection onto whatever row took that index, so the picker silently pointed at a
+process the user never chose.
 
-The contract now: a refresh may replace the rows and restore the selection, but
-it must leave the user's scroll position and typed input where they put them.
+The contract now: only a real pick — a click, or a double-click — may write to the
+"Process:" field or change what the picker targets. A refresh or a filter
+keystroke must leave the user's scroll position, selection and typed input alone.
 
 Skipped when ``PySide6`` isn't installed (the runtime dependency is opt-in via
 the ``app`` extra).
@@ -29,6 +33,9 @@ pytest.importorskip("PySide6", reason="App tests require PySide6 (install with [
 
 # Offscreen platform plugin: no display server needed, runs on CI.
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+from PySide6.QtCore import Qt  # noqa: E402 — import guarded by importorskip above
 
 
 @pytest.fixture(scope="module")
@@ -138,3 +145,66 @@ def test_clicking_a_row_still_fills_the_entry(qapp, dialog):
     dialog._table.selectRow(2)
     qapp.processEvents()
     assert dialog._entry.text() == str(dialog._selected_pid())
+
+
+def test_double_clicking_a_row_opens_that_row(qapp, dialog):
+    """The click is authoritative, even when the entry says something else.
+
+    Clicking a row that is already selected emits no ``selectionChanged``, so
+    the entry can still hold a name typed earlier — and ``_try_open`` only reads
+    the entry. Without this, double-clicking the highlighted row opened whatever
+    had been typed instead.
+    """
+    dialog._on_rows_ready(_rows(300))
+    dialog._table.selectRow(2)
+    qapp.processEvents()
+    clicked_pid = dialog._selected_pid()
+
+    dialog._entry.setText("notepad.exe")
+    opened = []
+    dialog._try_open = lambda: opened.append(dialog._entry.text())
+
+    dialog._table.doubleClicked.emit(dialog._proxy.index(2, dialog.COL_PID))
+    qapp.processEvents()
+    assert opened == [str(clicked_pid)]
+
+
+def test_filtering_away_the_selection_drops_it_instead_of_retargeting(qapp, dialog):
+    """Qt remaps a selection whose row the filter hid; the picker must not follow."""
+    dialog._on_rows_ready(_rows(300))
+    dialog._table.selectRow(120)
+    qapp.processEvents()
+    picked_pid = dialog._selected_pid()
+    assert picked_pid is not None
+
+    dialog._entry.setText("notepad.exe")
+    dialog._filter_edit.setText("proc12")  # hides the picked row
+    qapp.processEvents()
+
+    assert dialog._selected_pid() is None, "a hidden pick must not survive as another row"
+    assert dialog._entry.text() == "notepad.exe"
+
+    # And the tick that follows must not resurrect it either.
+    dialog._on_rows_ready(_rows(300))
+    qapp.processEvents()
+    assert dialog._entry.text() == "notepad.exe"
+
+
+def test_filtering_keeps_a_selection_that_survives_the_filter(qapp, dialog):
+    """Dropping the selection is only right when the filter actually hides it."""
+    rows = _rows(300)
+    dialog._on_rows_ready(rows)
+
+    # proc129 stays visible under the "proc12" filter (proc120..proc129 match).
+    target_pid = 1129
+    for row in range(dialog._proxy.rowCount()):
+        index = dialog._proxy.index(row, dialog.COL_PID)
+        if dialog._proxy.data(index, Qt.UserRole) == target_pid:
+            dialog._table.selectRow(row)
+            break
+    qapp.processEvents()
+    assert dialog._selected_pid() == target_pid
+
+    dialog._filter_edit.setText("proc12")
+    qapp.processEvents()
+    assert dialog._selected_pid() == target_pid

--- a/tests/app/test_open_process_dialog.py
+++ b/tests/app/test_open_process_dialog.py
@@ -15,9 +15,10 @@ same thing by a different route: hiding the selected row makes Qt remap the
 selection onto whatever row took that index, so the picker silently pointed at a
 process the user never chose.
 
-The contract now: only a real pick — a click, or a double-click — may write to the
-"Process:" field or change what the picker targets. A refresh or a filter
-keystroke must leave the user's scroll position, selection and typed input alone.
+The contract now: only a real pick — clicking a row, arrowing onto one, or
+double-clicking one — may write to the "Process:" field or change what the picker
+targets. A refresh tick or a filter keystroke must leave the user's scroll
+position, selection and typed input alone.
 
 Skipped when ``PySide6`` isn't installed (the runtime dependency is opt-in via
 the ``app`` extra).
@@ -33,9 +34,6 @@ pytest.importorskip("PySide6", reason="App tests require PySide6 (install with [
 
 # Offscreen platform plugin: no display server needed, runs on CI.
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
-
-
-from PySide6.QtCore import Qt  # noqa: E402 — import guarded by importorskip above
 
 
 @pytest.fixture(scope="module")
@@ -147,7 +145,7 @@ def test_clicking_a_row_still_fills_the_entry(qapp, dialog):
     assert dialog._entry.text() == str(dialog._selected_pid())
 
 
-def test_double_clicking_a_row_opens_that_row(qapp, dialog):
+def test_double_clicking_a_row_opens_that_row(qapp, dialog, monkeypatch):
     """The click is authoritative, even when the entry says something else.
 
     Clicking a row that is already selected emits no ``selectionChanged``, so
@@ -162,7 +160,7 @@ def test_double_clicking_a_row_opens_that_row(qapp, dialog):
 
     dialog._entry.setText("notepad.exe")
     opened = []
-    dialog._try_open = lambda: opened.append(dialog._entry.text())
+    monkeypatch.setattr(dialog, "_try_open", lambda: opened.append(dialog._entry.text()))
 
     dialog._table.doubleClicked.emit(dialog._proxy.index(2, dialog.COL_PID))
     qapp.processEvents()
@@ -192,6 +190,8 @@ def test_filtering_away_the_selection_drops_it_instead_of_retargeting(qapp, dial
 
 def test_filtering_keeps_a_selection_that_survives_the_filter(qapp, dialog):
     """Dropping the selection is only right when the filter actually hides it."""
+    from PySide6.QtCore import Qt
+
     rows = _rows(300)
     dialog._on_rows_ready(rows)
 
@@ -208,3 +208,46 @@ def test_filtering_keeps_a_selection_that_survives_the_filter(qapp, dialog):
     dialog._filter_edit.setText("proc12")
     qapp.processEvents()
     assert dialog._selected_pid() == target_pid
+
+
+def test_arrowing_onto_a_row_fills_the_entry(qapp, dialog):
+    """A keyboard pick is a pick too — the guard must not swallow it."""
+    from PySide6.QtCore import Qt
+    from PySide6.QtTest import QTest
+
+    dialog._on_rows_ready(_rows(300))
+    dialog._table.selectRow(2)
+    qapp.processEvents()
+    before = dialog._entry.text()
+
+    dialog._table.setFocus()
+    QTest.keyClick(dialog._table, Qt.Key_Down)
+    qapp.processEvents()
+
+    assert dialog._entry.text() == str(dialog._selected_pid())
+    assert dialog._entry.text() != before
+
+
+def test_refresh_under_an_active_filter_keeps_the_selection(qapp, dialog):
+    """The two fixes have to compose: the restore walks the *filtered* rows.
+
+    A tick that can't find the picked PID among the visible rows would silently
+    drop the selection.
+    """
+    rows = _rows(300)
+    dialog._on_rows_ready(rows)
+    dialog._table.selectRow(2)
+    qapp.processEvents()
+    picked_pid = dialog._selected_pid()
+    assert picked_pid is not None
+
+    # `_rows` names row i "proc{i:03d}" and gives it PID 1000 + i, so this
+    # filter leaves exactly the picked row visible.
+    dialog._filter_edit.setText(f"proc{picked_pid - 1000:03d}")
+    qapp.processEvents()
+    assert dialog._proxy.rowCount() == 1
+    assert dialog._selected_pid() == picked_pid
+
+    dialog._on_rows_ready(rows)  # the auto-refresh tick
+    qapp.processEvents()
+    assert dialog._selected_pid() == picked_pid

--- a/tests/app/test_open_process_dialog.py
+++ b/tests/app/test_open_process_dialog.py
@@ -147,6 +147,24 @@ def test_double_clicking_a_row_opens_that_row(qapp, dialog, monkeypatch):
     assert opened == [str(clicked_pid)]
 
 
+def test_clicking_the_selected_row_re_aims_the_entry(qapp, dialog, monkeypatch):
+    """Clicking the highlighted row emits no ``selectionChanged`` — but still counts."""
+    dialog._on_rows_ready(_rows(300))
+    dialog._table.selectRow(2)
+    qapp.processEvents()
+    clicked_pid = dialog._selected_pid()
+
+    dialog._entry.setText("notepad.exe")
+    opened = []
+    monkeypatch.setattr(dialog, "_try_open", lambda: opened.append(dialog._entry.text()))
+
+    dialog._table.clicked.emit(dialog._proxy.index(2, dialog.COL_PID))
+    qapp.processEvents()
+
+    assert dialog._entry.text() == str(clicked_pid)
+    assert opened == [], "a single click must not open anything"
+
+
 def test_filtering_away_the_selection_drops_it_instead_of_retargeting(qapp, dialog):
     """Qt remaps a selection whose row the filter hid; the picker must not follow."""
     dialog._on_rows_ready(_rows(300))

--- a/tests/app/test_open_process_dialog.py
+++ b/tests/app/test_open_process_dialog.py
@@ -9,8 +9,11 @@ the viewport — Qt ``scrollTo``s the current index — so as soon as the user h
 clicked any row, scrolling through the list snapped back to that row on every
 tick.
 
+The same tick also echoed the restored selection's PID into the "Process:" field,
+overwriting whatever the user had typed there.
+
 The contract now: a refresh may replace the rows and restore the selection, but
-it must leave the user's scroll position where they put it.
+it must leave the user's scroll position and typed input where they put them.
 
 Skipped when ``PySide6`` isn't installed (the runtime dependency is opt-in via
 the ``app`` extra).
@@ -107,3 +110,31 @@ def test_refresh_still_restores_the_selection(qapp, dialog):
     dialog._on_rows_ready(rows)
     qapp.processEvents()
     assert dialog._selected_pid() == selected_pid
+
+
+def test_refresh_does_not_overwrite_a_typed_process_name(qapp, dialog):
+    """Clicking a row fills the entry; a refresh tick must not refill it.
+
+    Otherwise a user who clicks a row, then types a name and presses Enter more
+    than one tick later opens the PID they clicked instead of what they typed.
+    """
+    rows = _rows(300)
+    dialog._on_rows_ready(rows)
+    dialog._table.selectRow(2)
+    qapp.processEvents()
+    assert dialog._entry.text(), "clicking a row is supposed to fill the entry"
+
+    dialog._entry.setText("notepad.exe")
+    dialog._on_rows_ready(rows)  # the auto-refresh tick
+    qapp.processEvents()
+    assert dialog._entry.text() == "notepad.exe"
+
+
+def test_clicking_a_row_still_fills_the_entry(qapp, dialog):
+    """The guard above must only cover the refresh, not a real selection."""
+    dialog._on_rows_ready(_rows(300))
+    qapp.processEvents()
+
+    dialog._table.selectRow(2)
+    qapp.processEvents()
+    assert dialog._entry.text() == str(dialog._selected_pid())

--- a/tests/app/test_open_process_dialog.py
+++ b/tests/app/test_open_process_dialog.py
@@ -122,7 +122,7 @@ def test_refresh_does_not_overwrite_a_typed_process_name(qapp, dialog):
 
 
 def test_clicking_a_row_still_fills_the_entry(qapp, dialog):
-    """The guard above must only cover the refresh, not a real selection."""
+    """A click is a pick: the refresh guard must not swallow it too."""
     dialog._on_rows_ready(_rows(300))
     qapp.processEvents()
 
@@ -132,7 +132,7 @@ def test_clicking_a_row_still_fills_the_entry(qapp, dialog):
 
 
 def test_double_clicking_a_row_opens_that_row(qapp, dialog, monkeypatch):
-    """The click wins over the entry, which ``_try_open`` is all that reads."""
+    """The double-click wins over the entry, which is all ``_try_open`` reads."""
     dialog._on_rows_ready(_rows(300))
     dialog._table.selectRow(2)
     qapp.processEvents()
@@ -191,7 +191,7 @@ def test_filtering_keeps_a_selection_that_survives_the_filter(qapp, dialog):
 
 
 def test_arrowing_onto_a_row_fills_the_entry(qapp, dialog):
-    """A keyboard pick is a pick too — the guard must not swallow it."""
+    """Arrowing onto a row is a pick too, so it must reach the entry."""
     from PySide6.QtCore import Qt
     from PySide6.QtTest import QTest
 
@@ -209,7 +209,7 @@ def test_arrowing_onto_a_row_fills_the_entry(qapp, dialog):
 
 
 def test_refresh_under_an_active_filter_keeps_the_selection(qapp, dialog):
-    """The two fixes compose: the restore walks the *filtered* rows."""
+    """A tick under a filter must find the picked PID among the *filtered* rows."""
     rows = _rows(300)
     dialog._on_rows_ready(rows)
     dialog._table.selectRow(2)

--- a/tests/app/test_open_process_dialog.py
+++ b/tests/app/test_open_process_dialog.py
@@ -3,22 +3,14 @@
 """
 Tests for ``PyMemoryEditor/app/open_process_dialog.py``.
 
-Regression cover for issue #75: the picker re-enumerates processes every few
-seconds, and each tick re-selected the previously picked row. Re-selecting moves
-the viewport — Qt ``scrollTo``s the current index — so as soon as the user had
-clicked any row, scrolling through the list snapped back to that row on every
-tick.
+Regression cover for issue #75 and its neighbours: the picker's re-enumeration
+tick used to move the viewport, overwrite the "Process:" field, and — via the
+Filter box — retarget the selection at a process the user never chose.
 
-The same tick also echoed the restored selection's PID into the "Process:" field,
-overwriting whatever the user had typed there. Typing in the Filter box did the
-same thing by a different route: hiding the selected row makes Qt remap the
-selection onto whatever row took that index, so the picker silently pointed at a
-process the user never chose.
-
-The contract now: only a real pick — clicking a row, arrowing onto one, or
+The contract: only a real pick — clicking a row, arrowing onto one, or
 double-clicking one — may write to the "Process:" field or change what the picker
-targets. A refresh tick or a filter keystroke must leave the user's scroll
-position, selection and typed input alone.
+targets. A refresh tick and a filter keystroke must leave both alone, along with
+the scroll position.
 
 Skipped when ``PySide6`` isn't installed (the runtime dependency is opt-in via
 the ``app`` extra).
@@ -54,9 +46,8 @@ def dialog(qapp, monkeypatch):
     """A shown picker whose own enumeration is inert.
 
     The real worker walks the live process table on a thread, so its results
-    could land mid-test and overwrite the rows we feed in. The tests call
-    ``_on_rows_ready`` directly instead, which is exactly what a refresh tick
-    does once the scan returns.
+    could land mid-test; the tests call ``_on_rows_ready`` directly instead,
+    which is what a refresh tick does once the scan returns.
     """
     from PyMemoryEditor.app import open_process_dialog
 
@@ -79,14 +70,14 @@ def dialog(qapp, monkeypatch):
 
 
 def test_refresh_keeps_the_scroll_position_after_a_row_was_clicked(qapp, dialog):
-    """The #75 repro: click a row near the top, scroll away, wait for a tick."""
+    """The #75 repro: click a row, scroll away, wait for a tick."""
     rows = _rows(300)
     dialog._on_rows_ready(rows)
-    dialog._table.selectRow(2)  # the single click from the report
+    dialog._table.selectRow(2)
     qapp.processEvents()
 
     scrollbar = dialog._table.verticalScrollBar()
-    scrollbar.setValue(150)  # the user scrolls down, away from the selection
+    scrollbar.setValue(150)
     qapp.processEvents()
     assert scrollbar.value() == 150, "the list must be scrollable for this to mean anything"
 
@@ -94,8 +85,7 @@ def test_refresh_keeps_the_scroll_position_after_a_row_was_clicked(qapp, dialog)
     qapp.processEvents()
     assert scrollbar.value() == 150
 
-    # The user-facing property behind that number: the restored selection must
-    # not have been dragged into view.
+    # The property behind that number: the restored selection stayed off-screen.
     selected = dialog._table.selectionModel().selectedRows()
     assert selected, "the tick is supposed to restore the selection"
     row_rect = dialog._table.visualRect(selected[0])
@@ -118,11 +108,7 @@ def test_refresh_still_restores_the_selection(qapp, dialog):
 
 
 def test_refresh_does_not_overwrite_a_typed_process_name(qapp, dialog):
-    """Clicking a row fills the entry; a refresh tick must not refill it.
-
-    Otherwise a user who clicks a row, then types a name and presses Enter more
-    than one tick later opens the PID they clicked instead of what they typed.
-    """
+    """A tick must not refill the entry the user typed into."""
     rows = _rows(300)
     dialog._on_rows_ready(rows)
     dialog._table.selectRow(2)
@@ -130,7 +116,7 @@ def test_refresh_does_not_overwrite_a_typed_process_name(qapp, dialog):
     assert dialog._entry.text(), "clicking a row is supposed to fill the entry"
 
     dialog._entry.setText("notepad.exe")
-    dialog._on_rows_ready(rows)  # the auto-refresh tick
+    dialog._on_rows_ready(rows)
     qapp.processEvents()
     assert dialog._entry.text() == "notepad.exe"
 
@@ -146,13 +132,7 @@ def test_clicking_a_row_still_fills_the_entry(qapp, dialog):
 
 
 def test_double_clicking_a_row_opens_that_row(qapp, dialog, monkeypatch):
-    """The click is authoritative, even when the entry says something else.
-
-    Clicking a row that is already selected emits no ``selectionChanged``, so
-    the entry can still hold a name typed earlier — and ``_try_open`` only reads
-    the entry. Without this, double-clicking the highlighted row opened whatever
-    had been typed instead.
-    """
+    """The click wins over the entry, which ``_try_open`` is all that reads."""
     dialog._on_rows_ready(_rows(300))
     dialog._table.selectRow(2)
     qapp.processEvents()
@@ -229,11 +209,7 @@ def test_arrowing_onto_a_row_fills_the_entry(qapp, dialog):
 
 
 def test_refresh_under_an_active_filter_keeps_the_selection(qapp, dialog):
-    """The two fixes have to compose: the restore walks the *filtered* rows.
-
-    A tick that can't find the picked PID among the visible rows would silently
-    drop the selection.
-    """
+    """The two fixes compose: the restore walks the *filtered* rows."""
     rows = _rows(300)
     dialog._on_rows_ready(rows)
     dialog._table.selectRow(2)
@@ -241,8 +217,7 @@ def test_refresh_under_an_active_filter_keeps_the_selection(qapp, dialog):
     picked_pid = dialog._selected_pid()
     assert picked_pid is not None
 
-    # `_rows` names row i "proc{i:03d}" and gives it PID 1000 + i, so this
-    # filter leaves exactly the picked row visible.
+    # `_rows` pairs PID 1000 + i with the name "proc{i:03d}".
     dialog._filter_edit.setText(f"proc{picked_pid - 1000:03d}")
     qapp.processEvents()
     assert dialog._proxy.rowCount() == 1

--- a/tests/app/test_open_process_dialog.py
+++ b/tests/app/test_open_process_dialog.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+
+"""
+Tests for ``PyMemoryEditor/app/open_process_dialog.py``.
+
+Regression cover for issue #75: the picker re-enumerates processes every few
+seconds, and each tick re-selected the previously picked row. Re-selecting moves
+the viewport — Qt ``scrollTo``s the current index — so as soon as the user had
+clicked any row, scrolling through the list snapped back to that row on every
+tick.
+
+The contract now: a refresh may replace the rows and restore the selection, but
+it must leave the user's scroll position where they put it.
+
+Skipped when ``PySide6`` isn't installed (the runtime dependency is opt-in via
+the ``app`` extra).
+"""
+
+import os
+from typing import List, Tuple
+
+import pytest
+
+
+pytest.importorskip("PySide6", reason="App tests require PySide6 (install with [app] extra).")
+
+# Offscreen platform plugin: no display server needed, runs on CI.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    """A single QApplication for the module (Qt allows only one per process)."""
+    from PySide6.QtWidgets import QApplication
+
+    return QApplication.instance() or QApplication([])
+
+
+def _rows(count: int) -> List[Tuple[int, str, int, str]]:
+    """Rows shaped like ``_ProcessListWorker.rows_ready`` emits them."""
+    return [(1000 + i, f"proc{i:03d}", 1024 * (i + 1), "user") for i in range(count)]
+
+
+@pytest.fixture
+def dialog(qapp, monkeypatch):
+    """A shown picker whose own enumeration is inert.
+
+    The real worker walks the live process table on a thread, so its results
+    could land mid-test and overwrite the rows we feed in. The tests call
+    ``_on_rows_ready`` directly instead, which is exactly what a refresh tick
+    does once the scan returns.
+    """
+    from PyMemoryEditor.app import open_process_dialog
+
+    class _InertWorker(open_process_dialog._ProcessListWorker):
+        def run(self) -> None:
+            return
+
+    monkeypatch.setattr(open_process_dialog, "_ProcessListWorker", _InertWorker)
+
+    dlg = open_process_dialog.OpenProcessDialog()
+    dlg._refresh_timer.stop()  # refreshes are driven by hand below
+    dlg.show()
+    qapp.processEvents()
+    try:
+        yield dlg
+    finally:
+        dlg.close()
+        dlg.deleteLater()
+        qapp.processEvents()
+
+
+def test_refresh_keeps_the_scroll_position_after_a_row_was_clicked(qapp, dialog):
+    """The #75 repro: click a row near the top, scroll away, wait for a tick."""
+    rows = _rows(300)
+    dialog._on_rows_ready(rows)
+    dialog._table.selectRow(2)  # the single click from the report
+    qapp.processEvents()
+
+    scrollbar = dialog._table.verticalScrollBar()
+    scrollbar.setValue(150)  # the user scrolls down, away from the selection
+    qapp.processEvents()
+    assert scrollbar.value() == 150, "the list must be scrollable for this to mean anything"
+
+    dialog._on_rows_ready(rows)  # the auto-refresh tick
+    qapp.processEvents()
+    assert scrollbar.value() == 150
+
+    # The user-facing property behind that number: the restored selection must
+    # not have been dragged into view.
+    selected = dialog._table.selectionModel().selectedRows()
+    assert selected, "the tick is supposed to restore the selection"
+    row_rect = dialog._table.visualRect(selected[0])
+    assert not row_rect.intersects(dialog._table.viewport().rect())
+
+
+def test_refresh_still_restores_the_selection(qapp, dialog):
+    """Preserving the viewport must not cost the selection the picker keeps."""
+    rows = _rows(300)
+    dialog._on_rows_ready(rows)
+    dialog._table.selectRow(2)
+    qapp.processEvents()
+
+    selected_pid = dialog._selected_pid()
+    assert selected_pid is not None
+
+    dialog._on_rows_ready(rows)
+    qapp.processEvents()
+    assert dialog._selected_pid() == selected_pid


### PR DESCRIPTION
Closes #75.

The picker's 3 s auto-refresh — and, it turned out, its Filter box and its own click handling — could take the user's scroll position, their typed input, and even their choice of process. All of it lives in one small cluster of handlers in `open_process_dialog.py`.

## 1. The scroll position (the issue)

Each tick restored the previously selected row with `QTableView.selectRow`. That moves the current index, and `QAbstractItemView::currentChanged` scrolls the view to the current index — so once the user had clicked any row, the list jumped back to that row on every tick and scrolling through a long process list was impossible.

Measured offscreen with 300 rows: click row 2, scroll to offset 150, one refresh tick → offset 2.

The fix takes the scroll offset before the model is rebuilt and puts it back after the selection is restored. Rebuilding the model is not the problem on its own — Qt defers the scrollbar range update, so the offset survives `setRowCount(0)` plus 300 `appendRow`s (150 before, 150 after, with no selection). That is why the restore has to sit *after* the `selectRow` call rather than merely around the rebuild.

Two alternatives were rejected:

- Restoring the selection with `selectionModel().select()` instead, so the current index is never moved. It does preserve the scroll position, but it leaves the current index invalid after every tick, which costs keyboard navigation.
- Anchoring on the top visible row's PID and using `scrollTo(..., PositionAtTop)`. More exact — restoring a raw `ScrollPerItem` value is a row index, so the view drifts by one row when a process sorting above the viewport starts or exits — but the picker now matches the save/restore pattern already used in `threads_dialog.py`, `modules_dialog.py` and `memory_map_dialog.py`. Worth revisiting for all four at once if the drift ever matters.

The auto-refresh itself is kept: the issue also suggests dropping it in favour of the existing Refresh button, but with the viewport preserved it no longer interrupts anyone.

## 2. The typed process name

Restoring the selection emits `selectionChanged`, and `_on_selection_changed` mirrored the selected PID into the "Process:" field unconditionally. Click a row, type a process name, and 3 s later the field held the old PID again — so pressing Enter opened the process that was clicked instead of the one that was typed. Against a live process list the typed text survived 1.7 s.

This one needed the click first: typing without ever selecting a row was always safe, and the Filter box at the top was never affected, which is why it went unnoticed.

The echo is right for a click and wrong for a refresh, so the restore now runs inside `_programmatic_selection()`, and `_on_selection_changed` ignores selection changes made under it. Blocking the selection model's signals instead would also have suppressed the view's own repaint of the row it just selected.

## 3. Clicking a row that is already highlighted

`_try_open` only ever reads the entry, and clicking a row that is already selected emits no `selectionChanged` in single-selection mode — so nothing re-synced the entry. Fixing (2) is what made this reachable: before, the next tick overwrote the entry and papered over it.

Reproduced with real mouse events: click a row (entry becomes `1296`), type a name, let a tick restore the selection, then click that same highlighted row — the entry still says `notepad.exe` while the row for 1296 is selected, and Open Process opens the name. With an emptied entry, the same click leaves Open warning "Type a PID or process name first" while a row sits highlighted.

`clicked` now aims the entry at the row it carries, and `_on_row_activated` (double-click) reuses that step before opening. A real double-click emits `clicked` then `doubleClicked` — verified by delivering the four mouse events — so the entry is aimed on the first release and `_try_open` still runs exactly once.

## 4. The Filter box retargeting the selection

Hiding the selected row does not clear the selection: Qt remaps it onto whatever row took that index. Measured — pick pid 1179, type a name, filter to `proc12`, and the entry reads `1129`, a process the user never chose; the next tick then cements it. The remap is now refused (the selection is dropped when the filter hides it, kept when it doesn't) and neither the remap nor that cleanup reaches the entry.

## Tests

New `tests/app/test_open_process_dialog.py`, following the conventions in `test_auto_refresh_dialog.py` (module-scoped `qapp`, offscreen platform, the enumeration worker stubbed out so the live process table can't land mid-test). Ten tests covering: the #75 repro (asserting the restored selection stayed *outside* the viewport, not just the scrollbar number), the selection surviving a tick, the typed name surviving a tick, a click and an arrow-key pick both still filling the entry, a click on the already-highlighted row re-aiming it without opening anything, the double-click opening the row it carries, the filter dropping a hidden pick instead of retargeting it, the filter keeping a visible one, and a tick under an active filter finding the picked PID among the filtered rows.

Each fix was mutation-checked: dropping the scroll restore, clearing the selection on any filter keystroke, swallowing every echo, un-wiring `clicked`, wiring `clicked` to the open path, and giving `doubleClicked` its old index-discarding lambda back each fail the tests that cover them.

`tests/app` is 113 passed; mypy and flake8 are clean. The 15 failures in the full suite are pre-existing macOS permission failures, unrelated (same 15 on a clean tree).