### PR TITLE
fix(macos): let a scan walk past a page whose pager declines to read

### DIFF
--- a/PyMemoryEditor/macos/functions.py
+++ b/PyMemoryEditor/macos/functions.py
@@ -299,10 +299,11 @@ def get_memory_regions(task: int, pid: int = 0) -> Generator[MemoryRegion, None,
 # KERN_MEMORY_ERROR is the same story one level down: the pager backing a page
 # declined to produce its data. The kernel header calls that failure
 # "temporary" in as many words, in explicit contrast with the permanent
-# KERN_MEMORY_FAILURE beside it. It is what file-backed, read-only mappings
-# (code segments, dylibs, the dyld shared cache) return, so any scan that walks
-# them — every pattern scan, and any value scan with "writable regions only"
-# turned off — hits it routinely and used to abort on the first one.
+# KERN_MEMORY_FAILURE beside it (the pair is spelled out in types.py). It is
+# what file-backed, read-only mappings (code segments, dylibs, the dyld shared
+# cache) return, so any scan that walks them — every pattern scan, and any value
+# scan with "writable regions only" turned off — hits it routinely, and used to
+# abort on the first one.
 _PAGE_GONE_KRS = (
     KERN_INVALID_ADDRESS,
     KERN_NO_ACCESS,

--- a/PyMemoryEditor/macos/functions.py
+++ b/PyMemoryEditor/macos/functions.py
@@ -38,6 +38,7 @@ from .libsystem import PROC_ALL_PIDS, libsystem, mach_error_message, mach_task_s
 from .types import (
     KERN_INVALID_ADDRESS,
     KERN_INVALID_ARGUMENT,
+    KERN_MEMORY_ERROR,
     KERN_NO_ACCESS,
     KERN_PROTECTION_FAILURE,
     KERN_SUCCESS,
@@ -294,10 +295,19 @@ def get_memory_regions(task: int, pid: int = 0) -> Generator[MemoryRegion, None,
 # KERN_NO_ACCESS / KERN_INVALID_ARGUMENT can also surface for guard pages and
 # freshly-unmapped pages on modern macOS; treating them as fatal aborts a scan
 # that should just skip the page.
+#
+# KERN_MEMORY_ERROR is the same story one level down: the pager backing a page
+# declined to produce its data. The kernel header calls that failure
+# "temporary" in as many words, in explicit contrast with the permanent
+# KERN_MEMORY_FAILURE beside it. It is what file-backed, read-only mappings
+# (code segments, dylibs, the dyld shared cache) return, so any scan that walks
+# them — every pattern scan, and any value scan with "writable regions only"
+# turned off — hits it routinely and used to abort on the first one.
 _PAGE_GONE_KRS = (
     KERN_INVALID_ADDRESS,
     KERN_NO_ACCESS,
     KERN_INVALID_ARGUMENT,
+    KERN_MEMORY_ERROR,
 )
 
 

--- a/PyMemoryEditor/macos/types.py
+++ b/PyMemoryEditor/macos/types.py
@@ -65,6 +65,12 @@ KERN_PROTECTION_FAILURE = 2
 KERN_INVALID_ARGUMENT = 4
 KERN_FAILURE = 5
 KERN_NO_ACCESS = 8
+# "During a page fault, the memory object indicated that the data could not be
+# returned. This failure may be temporary; future attempts to access this same
+# data may succeed, as defined by the memory object." — mach/kern_return.h.
+# Note the deliberate contrast with KERN_MEMORY_FAILURE (9) directly above it
+# in that header, whose comment ends "This failure is permanent."
+KERN_MEMORY_ERROR = 10
 
 
 class vm_region_basic_info_64(Structure):

--- a/PyMemoryEditor/macos/types.py
+++ b/PyMemoryEditor/macos/types.py
@@ -65,11 +65,17 @@ KERN_PROTECTION_FAILURE = 2
 KERN_INVALID_ARGUMENT = 4
 KERN_FAILURE = 5
 KERN_NO_ACCESS = 8
-# "During a page fault, the memory object indicated that the data could not be
-# returned. This failure may be temporary; future attempts to access this same
-# data may succeed, as defined by the memory object." — mach/kern_return.h.
-# Note the deliberate contrast with KERN_MEMORY_FAILURE (9) directly above it
-# in that header, whose comment ends "This failure is permanent."
+# These two are neighbours in mach/kern_return.h and are the line between a page
+# a scan may walk past and one it may not, so they are defined together:
+#
+#   9  "the target address refers to a memory object that has been destroyed.
+#       This failure is permanent."
+#  10  "the memory object indicated that the data could not be returned. This
+#       failure may be temporary; future attempts to access this same data may
+#       succeed, as defined by the memory object."
+#
+# Only the second belongs in functions._PAGE_GONE_KRS.
+KERN_MEMORY_FAILURE = 9
 KERN_MEMORY_ERROR = 10
 
 

--- a/tests/platforms/test_macos_transient_reads.py
+++ b/tests/platforms/test_macos_transient_reads.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+
+"""
+macOS-only test: which ``kern_return_t`` values a scan loop is allowed to walk
+past.
+
+The scan loops (``iter_search_results`` / ``iter_pattern_results``) skip a chunk
+they classify as transient and re-raise anything else, so this classification is
+the line between "a scan of a live process completes" and "it aborts on the
+first page the kernel declines to hand over". ``KERN_MEMORY_ERROR`` sat on the
+wrong side of it: file-backed read-only mappings (code segments, dylibs, the
+dyld shared cache) return it routinely, so every pattern scan — and any value
+scan with ``writeable_only`` off — died partway through.
+"""
+
+import sys
+
+import pytest
+
+
+if sys.platform != "darwin":
+    pytest.skip("macOS-only module", allow_module_level=True)
+
+
+from PyMemoryEditor.macos.functions import (  # noqa: E402
+    MachPartialReadError,
+    MachReadError,
+    _is_transient,
+)
+from PyMemoryEditor.macos.types import (  # noqa: E402
+    KERN_INVALID_ADDRESS,
+    KERN_INVALID_ARGUMENT,
+    KERN_MEMORY_ERROR,
+    KERN_NO_ACCESS,
+    KERN_PROTECTION_FAILURE,
+    KERN_SUCCESS,
+)
+
+
+# mach/kern_return.h documents each of these as a page the scan may walk past.
+# KERN_MEMORY_ERROR's own comment is explicit: "This failure may be temporary;
+# future attempts to access this same data may succeed."
+@pytest.mark.parametrize(
+    "kr",
+    (
+        KERN_INVALID_ADDRESS,
+        KERN_INVALID_ARGUMENT,
+        KERN_NO_ACCESS,
+        KERN_MEMORY_ERROR,
+    ),
+)
+def test_a_vanished_page_lets_the_scan_continue(kr):
+    assert _is_transient(MachReadError(kr, "read failed (kr=%d)" % kr))
+
+
+# The complement matters just as much: a permission or configuration problem
+# must reach the caller instead of being silently scanned past. KERN_MEMORY_
+# FAILURE (9) sits directly above KERN_MEMORY_ERROR in the header and is
+# documented as permanent, which is exactly the distinction being drawn.
+KERN_MEMORY_FAILURE = 9
+
+
+@pytest.mark.parametrize(
+    "kr", (KERN_SUCCESS, KERN_PROTECTION_FAILURE, KERN_MEMORY_FAILURE)
+)
+def test_a_real_failure_still_propagates(kr):
+    assert not _is_transient(MachReadError(kr, "read failed (kr=%d)" % kr))
+
+
+def test_a_short_read_lets_the_scan_continue():
+    """
+    A partial read means the transfer straddled a page that went away, so the
+    chunk is skipped like any other vanished page — the class carries
+    KERN_INVALID_ADDRESS for exactly that reason. Pinned here because the
+    behaviour rides on that constructor choice rather than on anything local.
+    """
+    assert _is_transient(MachPartialReadError(0x1000, 8, 64))
+
+
+def test_a_non_mach_error_is_never_transient():
+    assert not _is_transient(OSError("some unrelated failure"))
+    assert not _is_transient(ValueError("not an OSError at all"))

--- a/tests/platforms/test_macos_transient_reads.py
+++ b/tests/platforms/test_macos_transient_reads.py
@@ -28,12 +28,13 @@ from PyMemoryEditor.macos.functions import (  # noqa: E402
     _is_transient,
 )
 from PyMemoryEditor.macos.types import (  # noqa: E402
+    KERN_FAILURE,
     KERN_INVALID_ADDRESS,
     KERN_INVALID_ARGUMENT,
     KERN_MEMORY_ERROR,
+    KERN_MEMORY_FAILURE,
     KERN_NO_ACCESS,
     KERN_PROTECTION_FAILURE,
-    KERN_SUCCESS,
 )
 
 
@@ -54,14 +55,12 @@ def test_a_vanished_page_lets_the_scan_continue(kr):
 
 
 # The complement matters just as much: a permission or configuration problem
-# must reach the caller instead of being silently scanned past. KERN_MEMORY_
-# FAILURE (9) sits directly above KERN_MEMORY_ERROR in the header and is
-# documented as permanent, which is exactly the distinction being drawn.
-KERN_MEMORY_FAILURE = 9
-
-
+# must reach the caller instead of being silently scanned past. The header puts
+# KERN_MEMORY_FAILURE directly above KERN_MEMORY_ERROR and documents it as
+# permanent, which is exactly the distinction being drawn here; KERN_FAILURE is
+# what task_for_pid returns without the debugger entitlement.
 @pytest.mark.parametrize(
-    "kr", (KERN_SUCCESS, KERN_PROTECTION_FAILURE, KERN_MEMORY_FAILURE)
+    "kr", (KERN_FAILURE, KERN_PROTECTION_FAILURE, KERN_MEMORY_FAILURE)
 )
 def test_a_real_failure_still_propagates(kr):
     assert not _is_transient(MachReadError(kr, "read failed (kr=%d)" % kr))


### PR DESCRIPTION
**Why is this PR necessary, what does it do?**

A scan of a live process on macOS aborts part-way through with

```
MachReadError: mach_vm_read_overwrite failed: (os/kern) memory error (kr=10)
```

throwing away the rest of the address space. The addresses found before the bad
page survive in the results table, so the app ends up in a confusing half-state:
a populated result list *and* an error dialog.

kr=10 is `KERN_MEMORY_ERROR`, and `mach/kern_return.h` documents it as:

> During a page fault, the memory object indicated that the data could not be
> returned. **This failure may be temporary;** future attempts to access this
> same data may succeed, as defined by the memory object.

— in deliberate contrast with `KERN_MEMORY_FAILURE` (9) immediately above it in
that header, whose comment ends "This failure is permanent."

So by the kernel's own definition it belongs in `_PAGE_GONE_KRS` alongside the
three codes already there. It was simply missed — it wasn't even defined in
`macos/types.py`.

Nothing else needed changing. The tolerance machinery already exists and is
already wired into all three entry points (`search_addresses_by_value`,
`search_addresses_by_pattern`, `search_values_by_addresses` all pass
`transient_error_check=_is_transient`). The code was just on the wrong side of
the line `_is_transient` draws, so `iter_search_results` and
`iter_pattern_results` took their `raise` branch and killed the scan.

**Why it shows up on pattern scans first**

`KERN_MEMORY_ERROR` comes from a *pager* declining to produce a page, so it
turns up on file-backed read-only mappings — code segments, dylibs, the dyld
shared cache. A pattern scan deliberately ignores `writeable_only` (an AOB
signature normally lives in code), so it walks those; a value scan with the
app's default "writable regions only" never goes near them. Measured on a
trivial Python process:

```
regions total              :  148
pattern scan (regex / AOB) :  135   <- ignores writeable_only
value scan (writable only) :   58   <- the app's default

read-only regions a default value scan never walks:  77
```

Turning "writable regions only" off reproduces it with any value type, which is
how this was confirmed rather than assumed.

**Checklist (complete all items)**:

- [x] Added tests as necessary.
- [x] There is no breaking change for existing features.

**References:**

No references to be shared.

**Notes:**

The new test pins both sides of the classification: the four codes a scan may
walk past, and the ones that must still reach the caller (a protection failure
or the permanent `KERN_MEMORY_FAILURE`) so this doesn't drift into swallowing
real permission problems.

On the machine this was found on, the entire `tests/memory` and `tests/scan`
suite failed this way — 15 tests, all with kr=10. They pass now. Worth noting
that they pass *legitimately*: those tests plant a value or a byte marker and
assert it is found (`assert address in hits`), so the scans are completing and
matching, not quietly finding nothing.

Linux is unaffected — it has its own `_is_transient` over a separate errno set.
