### PR TITLE
chore: bump version to 2.2.0

### DIFF
--- a/PyMemoryEditor/__init__.py
+++ b/PyMemoryEditor/__init__.py
@@ -8,7 +8,7 @@ Supported platforms: Windows, Linux and macOS (32-bit and 64-bit).
 """
 
 __author__ = "Jean Loui Bernard Silva de Jesus"
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 import logging
 import sys


### PR DESCRIPTION
**Why is this PR necessary, what does it do?**

Bumps `__version__` to 2.2.0 for the four changes that have landed since the
2.1.0 bump (#81):

| | |
|---|---|
| #82 | report an exited target once instead of spamming error dialogs |
| #84 | stop the process-list refresh from stomping on scroll position and typed input |
| #88 | macOS: let a scan walk past a page whose pager declines to read |
| #87 | infer the byte-array scan width from the value entered (closes #79) |

**Minor rather than patch**, because #87 is not only a fix. Alongside closing
\#79 it adds a capability that did not exist in any form: an IDA pattern is a
usable cheat-table entry type, and its `?` wildcard means "keep the byte that is
already there" on a write, so `48 8B ? ? 90` patches one byte and leaves the
operands alone. It also changes behaviour users will notice — the Length field
became a read-only readout for the value-sized types, an empty text value is
refused instead of scanning for NUL bytes, and "Increased/Decreased Value By" is
refused for String / Byte Array instead of silently dropping every address.

That matches the precedent for 2.1.0 itself, which was a minor bump carried by a
single `feat` (`read_process_memory_into`, #72).

**Not major**: `PyMemoryEditor.__all__` is untouched, `compile_pattern` is
byte-for-byte identical to before (verified differentially against the previous
implementation), and the cheat table's JSON round-trips on every value type, so
saved tables keep loading.

**Checklist (complete all items)**:

- [x] Added tests as necessary.
- [x] There is no breaking change for existing features.

**References:**

Closes nothing; follows #87 and #88.

**Notes:**

One line changes — `pyproject.toml` declares `dynamic = ["version"]` and
`[tool.hatch.version]` reads it from `PyMemoryEditor/__init__.py`, so that is
the only place the number lives. Confirmed by building the wheel:
`pymemoryeditor-2.2.0-py3-none-any.whl`.

Suite is green at 562 passed / 13 skipped and `make lint` is clean.
