### PR TITLE
docs: drop the duplicated feature list from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,32 +80,6 @@ That's it — read, write or scan another process in three lines, the same way o
 
 ---
 
-## What's inside
-
-### 🐍 The Python library
-
-Full control over another process's memory — in a few lines of Python:
-
-- ✅ **Read & write** values (`int`, `float`, `bool`, `str`, `bytes`)
-- 🔍 **Value scan** with eight comparison modes
-- 🎯 **Pattern scan** (IDA-style AOB & regex)
-- 🔗 **Pointer chains** + a live `RemotePointer` handle
-- 🧭 **Pointer scan** — find static pointers that survive ASLR
-- 🗺️ **Memory map**, **modules**, **threads**
-- 🧱 **Allocate & free** remote memory (Windows / macOS)
-
-### 🖥️ The bundled GUI app
-
-All the library's power — no code required:
-- ⚡ **Zero setup** — attach to a process and start scanning in seconds
-- 🧲 **Refine workflow** — First Scan → Next Scan with live visual feedback
-- 📋 **Cheat table** — freeze / write values on the fly, JSON import/export
-- 🔬 **Hex viewer** — browse raw memory and write back inline
-- 🧩 **Pointer scan UI** — scan, export & rescan across sessions with a few clicks
-- 🎨 **One-click access** — every feature at your fingertips, no code needed
-
----
-
 ## 📖 Documentation
 
 Full documentation lives at **[pymemoryeditor.readthedocs.io](https://pymemoryeditor.readthedocs.io)** — installation, the Cheat Engine workflow, every method and parameter, the GUI app guide, platform notes and troubleshooting.


### PR DESCRIPTION
**Why is this PR necessary, what does it do?**

Removes the "What's inside" section from the README.

It listed the library's capabilities and the GUI app's, and the Documentation
table immediately below it already points at every one of them — searching,
pattern scan, pointers, pointer scan, the app, the API reference. Two lists of
the same thing drift apart, and the one that goes stale is the one nobody
remembers to edit when a feature lands.

The README keeps what only it can do: what the project is, how to install it,
and the three-line example.

**Checklist (complete all items)**:

- [x] Added tests as necessary.
- [x] There is no breaking change for existing features.

**References:**

No references to be shared.

**Notes:**

Nothing links to the removed section — no `#whats-inside` anchor anywhere in
`README.md`, `docs/` or `.github/`. (`docs/app.md` has a heading with the same
name, but it is that file's own section and is not referenced from outside it.)
The surrounding text still reads continuously: example → "That's it — read,
write or scan another process in three lines" → Documentation.
