### PR TITLE
docs: add a Codecov coverage badge to the README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A pure-Python library (built on [ctypes](https://docs.python.org/3/library/ctype
 
 <p align="center">
   <a href="https://github.com/JeanExtreme002/PyMemoryEditor/actions/workflows/python-package.yml"><img src="https://github.com/JeanExtreme002/PyMemoryEditor/actions/workflows/python-package.yml/badge.svg" alt="Python Package" /></a>
+  <a href="https://codecov.io/gh/JeanExtreme002/PyMemoryEditor"><img src="https://codecov.io/gh/JeanExtreme002/PyMemoryEditor/branch/main/graph/badge.svg" alt="Coverage" /></a>
   <a href="https://pypi.org/project/PyMemoryEditor/"><img src="https://img.shields.io/pypi/v/PyMemoryEditor" alt="Pypi" /></a>
   <a href="https://github.com/JeanExtreme002/PyMemoryEditor"><img src="https://img.shields.io/pypi/l/PyMemoryEditor" alt="License" /></a>
   <a href="https://github.com/JeanExtreme002/PyMemoryEditor"><img src="https://img.shields.io/badge/python-3.10+-8A2BE2" alt="Python Version" /></a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@
 
 <p align="center">
   <a href="https://github.com/JeanExtreme002/PyMemoryEditor/actions/workflows/python-package.yml"><img src="https://github.com/JeanExtreme002/PyMemoryEditor/actions/workflows/python-package.yml/badge.svg" alt="Python Package" /></a>
+  <a href="https://codecov.io/gh/JeanExtreme002/PyMemoryEditor"><img src="https://codecov.io/gh/JeanExtreme002/PyMemoryEditor/branch/main/graph/badge.svg" alt="Coverage" /></a>
   <a href="https://pypi.org/project/PyMemoryEditor/"><img src="https://img.shields.io/pypi/v/PyMemoryEditor" alt="Pypi" /></a>
   <a href="https://github.com/JeanExtreme002/PyMemoryEditor"><img src="https://img.shields.io/pypi/l/PyMemoryEditor" alt="License" /></a>
   <a href="https://github.com/JeanExtreme002/PyMemoryEditor"><img src="https://img.shields.io/badge/python-3.10+-8A2BE2" alt="Python Version" /></a>


### PR DESCRIPTION
## What

Adds a Codecov coverage badge to the badge row in `README.md` and `docs/index.md`.

## Why

The CI workflow already uploads coverage to Codecov from every cell of the
build matrix (plus the `build-speed` job), and `codecov.yml` already tunes the
statuses to informational — but nothing surfaced the resulting number to
anyone reading the project. The badge closes that gap.

## Notes

- The `CODECOV_TOKEN` repository secret has been created, so uploads are now
  authenticated instead of relying on tokenless upload.
- The badge will read `unknown` until the first authenticated report lands on
  `main`; it fills in on the next run of `Python Package`.