### PR TITLE
docs: move the platform line below the badge row

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@ A pure-Python library (built on [ctypes](https://docs.python.org/3/library/ctype
 </p>
 
 <p align="center">
-  Runs on <b>🪟 Windows</b> · <b>🐧 Linux</b> · <b>🍎 macOS</b> — 32-bit and 64-bit.
-</p>
-
-<p align="center">
   <a href="https://github.com/JeanExtreme002/PyMemoryEditor/actions/workflows/python-package.yml"><img src="https://github.com/JeanExtreme002/PyMemoryEditor/actions/workflows/python-package.yml/badge.svg" alt="Python Package" /></a>
   <a href="https://codecov.io/gh/JeanExtreme002/PyMemoryEditor"><img src="https://codecov.io/gh/JeanExtreme002/PyMemoryEditor/branch/main/graph/badge.svg" alt="Coverage" /></a>
   <a href="https://pypi.org/project/PyMemoryEditor/"><img src="https://img.shields.io/pypi/v/PyMemoryEditor" alt="Pypi" /></a>
   <a href="https://github.com/JeanExtreme002/PyMemoryEditor"><img src="https://img.shields.io/pypi/l/PyMemoryEditor" alt="License" /></a>
   <a href="https://github.com/JeanExtreme002/PyMemoryEditor"><img src="https://img.shields.io/badge/python-3.10+-8A2BE2" alt="Python Version" /></a>
   <a href="https://pypi.org/project/PyMemoryEditor/"><img src="https://static.pepy.tech/personalized-badge/pymemoryeditor?period=total&units=international_system&left_color=grey&right_color=orange&left_text=Downloads" alt="Downloads" /></a>
+</p>
+
+<p align="center">
+  Runs on <b>Windows</b> · <b>Linux</b> · <b>macOS</b> — 32-bit and 64-bit.
 </p>
 
 <p align="center">


### PR DESCRIPTION
## What

Moves the "Runs on Windows · Linux · macOS" line in `README.md` from above the badge row to below it, and drops the OS emojis from it.

The badges now sit directly under the tagline, so the two centred text blocks at the top are no longer split apart by them.

## Note

`docs/index.md` carries the same block and still has it in the old position, with the emojis. The two headers have been kept in sync so far, so they now differ — happy to mirror this there in a follow-up if that is wanted.