### PR TITLE
chore: bump version to 2.2.1

### DIFF
--- a/PyMemoryEditor/__init__.py
+++ b/PyMemoryEditor/__init__.py
@@ -8,7 +8,7 @@ Supported platforms: Windows, Linux and macOS (32-bit and 64-bit).
 """
 
 __author__ = "Jean Loui Bernard Silva de Jesus"
-__version__ = "2.2.0"
+__version__ = "2.2.1"
 
 import logging
 import sys


### PR DESCRIPTION
## What

Bumps `__version__` in `PyMemoryEditor/__init__.py` from `2.2.0` to `2.2.1`.

## Why patch

The only change to the shipped library since the 2.2.0 bump is the macOS scan fix in a859e85 — `search_by_value` / `search_by_pattern` no longer abort the whole sweep when the kernel refuses to hand over one range (`KERN_PROTECTION_FAILURE`). No API change and no new feature; the rest of the window (#91, #92, #93) was CI and docs.

The strict behaviour is unchanged for `search_by_addresses`, whose documented `raise_error=True` still reports a read it could not perform.

## Changes since 2.2.0

- #91 — Codecov badge in the README and docs
- #92 — macOS cell in CI, so the merged Codecov report covers all three backends (coverage 71% → 89%), plus the macOS scan fix above
- #93 — README platform line moved below the badge row