### PR TITLE
feat(mcp): raise the scan result cap and bound open sessions

### DIFF
--- a/PyMemoryEditor/mcp/config.py
+++ b/PyMemoryEditor/mcp/config.py
@@ -47,11 +47,26 @@ Transport = Literal["stdio", "sse", "streamable-http"]
 #: keeping them all would blow out the server's memory for a result set no
 #: refine loop can use anyway. At the cap the scan stops early and says so.
 #:
-#: 100 000 costs 4.2 MB per result set and 21 ms to sort, against 2.1 MB and
-#: 10 ms at the old 50 000; wall clock is unchanged, since the 30-second
-#: budget binds long before the cap does. The gain is that a scan whose true
-#: hit count sits between the two stops being flagged ``partial``, and
-#: refining a truncated set can converge on an address that was never in it.
+#: 100 000 costs 4.2 MB per result set against 2.1 MB, and 21 ms to sort
+#: against 10 ms. The figure that matters is not per set, though: a session
+#: keeps ``MAX_SCANS_PER_SESSION`` (20) of them and a server keeps
+#: ``MAX_OPEN_SESSIONS`` (8) sessions, so the ceiling on retained addresses
+#: goes from ~336 MB to ~672 MB. Reaching it needs 160 capped result sets,
+#: which a long refine chain across several targets can do.
+#:
+#: What it buys: a scan whose true hit count falls between the two ceilings
+#: stops being flagged ``partial``, and refining a truncated set can converge
+#: on an address that was never in it. That case is real but narrow — above
+#: the new ceiling nothing changes, and a common value like ``int 0`` matches
+#: millions and is out of reach at any sane cap.
+#:
+#: What it costs in time depends on the value's density, and an earlier
+#: version of this comment got that wrong. Measured on ``int 0``, reaching
+#: either ceiling took 0.02s against 0.03s — but that is the dense case, where
+#: hits arrive faster than the clock can spend. For a sparser value the scan
+#: has to walk further to collect twice as many hits, so the time roughly
+#: doubles up to the 30-second budget. "Wall clock is unchanged" was true of
+#: one measurement, not of the change.
 DEFAULT_MAX_SCAN_RESULTS = 100_000
 
 #: Wall-clock budget for one scan, in seconds. A full address-space scan of a

--- a/PyMemoryEditor/mcp/config.py
+++ b/PyMemoryEditor/mcp/config.py
@@ -46,7 +46,13 @@ Transport = Literal["stdio", "sse", "streamable-http"]
 #: value (``int`` ``0``, ``100``) legitimately matches millions of addresses;
 #: keeping them all would blow out the server's memory for a result set no
 #: refine loop can use anyway. At the cap the scan stops early and says so.
-DEFAULT_MAX_SCAN_RESULTS = 50_000
+#:
+#: 100 000 costs 4.2 MB per result set and 21 ms to sort, against 2.1 MB and
+#: 10 ms at the old 50 000; wall clock is unchanged, since the 30-second
+#: budget binds long before the cap does. The gain is that a scan whose true
+#: hit count sits between the two stops being flagged ``partial``, and
+#: refining a truncated set can converge on an address that was never in it.
+DEFAULT_MAX_SCAN_RESULTS = 100_000
 
 #: Wall-clock budget for one scan, in seconds. A full address-space scan of a
 #: large process takes minutes — long past the point where an MCP client gives

--- a/PyMemoryEditor/mcp/server.py
+++ b/PyMemoryEditor/mcp/server.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence, Tuple
 
 from .. import __version__
 from .config import ServerConfig, parse_args
-from .session import MAX_OPEN_SESSIONS, SessionError, host_platform
+from .session import SessionError, host_platform
 from .toolset import MemoryToolset, ToolError
 
 if TYPE_CHECKING:  # pragma: no cover - import cost avoided at runtime
@@ -243,11 +243,15 @@ def _register_open_process(server: "MCPServer", toolset: MemoryToolset) -> None:
         # user was asked to approve an attach, approved it, and then got told
         # the server was full. An approval is the most expensive step here and
         # the one thing this server must not spend carelessly.
-        if toolset.store.at_capacity():
+        #
+        # The store renders the message, rather than this having its own: the
+        # first version here named neither the open sessions nor their scan
+        # counts, so the path a model actually hits was the less useful one.
+        refusal = toolset.store.capacity_refusal(found_pid)
+        if refusal is not None:
             raise SdkToolError(
-                "Not asking to attach to \"%s\" (pid %d): this server already "
-                "has %d processes open, which is the limit. Close one with "
-                "close_process first." % (found_name, found_pid, MAX_OPEN_SESSIONS)
+                'Not asking to attach to "%s" (pid %d): %s'
+                % (found_name or "unknown", found_pid, refusal)
             )
 
         try:

--- a/PyMemoryEditor/mcp/server.py
+++ b/PyMemoryEditor/mcp/server.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence, Tuple
 
 from .. import __version__
 from .config import ServerConfig, parse_args
-from .session import SessionError, host_platform
+from .session import MAX_OPEN_SESSIONS, SessionError, host_platform
 from .toolset import MemoryToolset, ToolError
 
 if TYPE_CHECKING:  # pragma: no cover - import cost avoided at runtime
@@ -237,6 +237,18 @@ def _register_open_process(server: "MCPServer", toolset: MemoryToolset) -> None:
 
         if not _can_elicit(ctx):
             raise SdkToolError(decision.reason)
+
+        # Before the prompt, not after. The cap lives in SessionStore.open,
+        # which runs once the handle is already open -- so without this the
+        # user was asked to approve an attach, approved it, and then got told
+        # the server was full. An approval is the most expensive step here and
+        # the one thing this server must not spend carelessly.
+        if toolset.store.at_capacity():
+            raise SdkToolError(
+                "Not asking to attach to \"%s\" (pid %d): this server already "
+                "has %d processes open, which is the limit. Close one with "
+                "close_process first." % (found_name, found_pid, MAX_OPEN_SESSIONS)
+            )
 
         try:
             answer = await ctx.elicit(

--- a/PyMemoryEditor/mcp/session.py
+++ b/PyMemoryEditor/mcp/session.py
@@ -38,6 +38,12 @@ from ..process.region import MemoryRegion, MemoryRegionSnapshot
 #: Result sets retained per session before the oldest is evicted.
 MAX_SCANS_PER_SESSION = 20
 
+#: Processes one server keeps open at once. Refuses rather than evicting,
+#: unlike the scan cap above: a session owns an OS handle, and closing one out
+#: from under the model is not something it can detect. Bounds handle
+#: exhaustion, since nothing obliges a model to call ``close_process``.
+MAX_OPEN_SESSIONS = 8
+
 
 class SessionError(Exception):
     """An unknown or expired session/scan id.
@@ -178,8 +184,28 @@ class SessionStore:
         self._lock = threading.Lock()
 
     def open(self, process: AbstractProcess, pid: int, name: str) -> Session:
-        """Register an already-opened process and return its session."""
+        """Register an already-opened process and return its session.
+
+        :raises SessionError: if :data:`MAX_OPEN_SESSIONS` are already open.
+            The caller owns the handle it passed in and must close it.
+        """
         with self._lock:
+            if len(self._sessions) >= MAX_OPEN_SESSIONS:
+                raise SessionError(
+                    "This server already has %d processes open, which is the "
+                    "limit. Close one you are done with — close_process(%s) "
+                    "frees the oldest — and attach again. Open sessions: %s."
+                    % (
+                        MAX_OPEN_SESSIONS,
+                        next(iter(self._sessions)),
+                        ", ".join(
+                            "%s (%s, pid %d)"
+                            % (sid, session.name or "?", session.pid)
+                            for sid, session in self._sessions.items()
+                        ),
+                    )
+                )
+
             session_id = "proc-%d" % next(self._session_ids)
             session = Session(
                 session_id=session_id, process=process, pid=pid, name=name
@@ -377,6 +403,7 @@ def host_platform() -> str:
 
 
 __all__ = (
+    "MAX_OPEN_SESSIONS",
     "MAX_SCANS_PER_SESSION",
     "ScanResult",
     "Session",

--- a/PyMemoryEditor/mcp/session.py
+++ b/PyMemoryEditor/mcp/session.py
@@ -206,24 +206,32 @@ class SessionStore:
         :raises SessionError: if :data:`MAX_OPEN_SESSIONS` are already open.
             The caller owns the handle it passed in and must close it.
         """
-        with self._lock:
-            crowded = len(self._sessions) >= MAX_OPEN_SESSIONS
+        # Loop, rather than deciding to reap from a check taken earlier under
+        # a different acquisition: the store can fill between the two, and then
+        # a slot held by an exited process would be refused without anyone
+        # having looked. At most one reap — a second pass finds nothing new,
+        # and refusing has to terminate.
+        reaped = False
 
-        if crowded:
-            # Outside the lock: reaping closes handles, which takes it again.
-            self._reap_dead()
+        while True:
+            with self._lock:
+                refusal = self._refusal_locked(pid)
 
-        with self._lock:
-            refusal = self._refusal_locked(pid)
-            if refusal is not None:
+                if refusal is None:
+                    session_id = "proc-%d" % next(self._session_ids)
+                    session = Session(
+                        session_id=session_id, process=process,
+                        pid=pid, name=name,
+                    )
+                    self._sessions[session_id] = session
+                    return session
+
+            if reaped:
                 raise SessionError(refusal)
 
-            session_id = "proc-%d" % next(self._session_ids)
-            session = Session(
-                session_id=session_id, process=process, pid=pid, name=name
-            )
-            self._sessions[session_id] = session
-            return session
+            # Outside the lock: reaping closes handles, which takes it again.
+            self._reap_dead()
+            reaped = True
 
     def _reap_dead(self) -> List[str]:
         """Drop sessions whose target no longer exists. Caller holds no lock.
@@ -285,6 +293,12 @@ class SessionStore:
         then every thread inserted. Demonstrated with 12 concurrent opens
         against a cap of 8.
         """
+        # Deterministic, so a refactor that checks capacity outside the lock
+        # fails here instead of in a timing test. That regression happened
+        # once: the check and the insert were split across two acquisitions,
+        # every racing thread saw room, and the cap was exceeded.
+        assert self._lock.locked(), "capacity must be judged under the lock"
+
         if len(self._sessions) < MAX_OPEN_SESSIONS:
             return None
 

--- a/PyMemoryEditor/mcp/session.py
+++ b/PyMemoryEditor/mcp/session.py
@@ -206,42 +206,11 @@ class SessionStore:
         :raises SessionError: if :data:`MAX_OPEN_SESSIONS` are already open.
             The caller owns the handle it passed in and must close it.
         """
-        if len(self._sessions) >= MAX_OPEN_SESSIONS:
-            self._reap_dead()
+        refusal = self.capacity_refusal(pid)
+        if refusal is not None:
+            raise SessionError(refusal)
 
         with self._lock:
-            if len(self._sessions) >= MAX_OPEN_SESSIONS:
-                # No "close the oldest": the oldest is usually the target the
-                # whole session has been refining, and close_process discards
-                # its scan results too. The list is given instead, so the
-                # choice is made on what each session holds.
-                existing = [
-                    sid for sid, s in self._sessions.items() if s.pid == pid
-                ]
-                already = (
-                    " Note that pid %d is already open as %s — reuse that id "
-                    "rather than attaching again." % (pid, existing[0])
-                    if existing
-                    else ""
-                )
-                raise SessionError(
-                    "This server already has %d processes open, which is the "
-                    "limit, and all of them are live. Close whichever you are "
-                    "done with (close_process also discards that session's "
-                    "scan results) and attach again. Open: %s.%s"
-                    % (
-                        MAX_OPEN_SESSIONS,
-                        ", ".join(
-                            "%s (%s, pid %d, %d scan%s)"
-                            % (sid, session.name or "?", session.pid,
-                               len(session.scan_ids),
-                               "" if len(session.scan_ids) == 1 else "s")
-                            for sid, session in self._sessions.items()
-                        ),
-                        already,
-                    )
-                )
-
             session_id = "proc-%d" % next(self._session_ids)
             session = Session(
                 session_id=session_id, process=process, pid=pid, name=name
@@ -282,26 +251,64 @@ class SessionStore:
         """Whether this session's target still exists."""
         return _looks_alive(self.get(session_id).pid)
 
-    def at_capacity(self) -> bool:
-        """Whether :meth:`open` would refuse right now.
+    def capacity_refusal(self, pid: int = 0) -> Optional[str]:
+        """The reason :meth:`open` would refuse right now, or ``None``.
 
-        Lets a caller fail before doing something expensive that the refusal
-        would waste — the protocol layer asks this before prompting the user,
-        since spending an approval on an attach that cannot happen is worse
-        than refusing outright. :meth:`open` stays the authority: this is a
-        hint, and the two can differ under a concurrent open.
+        One message, rendered once. The protocol layer asks this *before*
+        prompting the user — spending an approval on an attach that cannot
+        happen is worse than refusing outright — and :meth:`open` raises it as
+        the authoritative guard. Duplicating the text gave the early path a
+        worse message than the late one, which is the path a model actually
+        hits.
 
-        Reaps first, or this would report a server full of exited processes as
-        full when `open` would have made room.
+        Reaps first, or a server full of exited processes reports as full when
+        :meth:`open` would have made room.
         """
         with self._lock:
             if len(self._sessions) < MAX_OPEN_SESSIONS:
-                return False
+                return None
 
         self._reap_dead()
 
         with self._lock:
-            return len(self._sessions) >= MAX_OPEN_SESSIONS
+            if len(self._sessions) < MAX_OPEN_SESSIONS:
+                return None
+
+            # No "close the oldest": the oldest is usually the target the whole
+            # session has been refining, and close_process discards its scan
+            # results too. The list is given instead, so the choice is made on
+            # what each session holds.
+            existing = [
+                sid for sid, session in self._sessions.items()
+                if session.pid == pid
+            ]
+            already = (
+                " Note that pid %d is already open as %s — reuse that id "
+                "rather than attaching again." % (pid, existing[0])
+                if existing
+                else ""
+            )
+            return (
+                "This server already has %d processes open, which is the "
+                "limit, and all of them are live. Close whichever you are "
+                "done with (close_process also discards that session's scan "
+                "results) and attach again. Open: %s.%s"
+                % (
+                    MAX_OPEN_SESSIONS,
+                    ", ".join(
+                        "%s (%s, pid %d, %d scan%s)"
+                        % (sid, session.name or "?", session.pid,
+                           len(session.scan_ids),
+                           "" if len(session.scan_ids) == 1 else "s")
+                        for sid, session in self._sessions.items()
+                    ),
+                    already,
+                )
+            )
+
+    def at_capacity(self) -> bool:
+        """Whether :meth:`open` would refuse right now."""
+        return self.capacity_refusal() is not None
 
     def get(self, session_id: str) -> Session:
         """Look up a session, or explain how to obtain a valid id."""

--- a/PyMemoryEditor/mcp/session.py
+++ b/PyMemoryEditor/mcp/session.py
@@ -169,7 +169,7 @@ class Session:
         return tuple(self._scan_order)
 
 
-def _looks_alive(pid: int) -> bool:
+def looks_alive(pid: int) -> bool:
     """``pid_exists``, but a pid the OS will not even accept reads as dead.
 
     The reaper runs inside ``open``, so anything raised here escapes as
@@ -206,11 +206,18 @@ class SessionStore:
         :raises SessionError: if :data:`MAX_OPEN_SESSIONS` are already open.
             The caller owns the handle it passed in and must close it.
         """
-        refusal = self.capacity_refusal(pid)
-        if refusal is not None:
-            raise SessionError(refusal)
+        with self._lock:
+            crowded = len(self._sessions) >= MAX_OPEN_SESSIONS
+
+        if crowded:
+            # Outside the lock: reaping closes handles, which takes it again.
+            self._reap_dead()
 
         with self._lock:
+            refusal = self._refusal_locked(pid)
+            if refusal is not None:
+                raise SessionError(refusal)
+
             session_id = "proc-%d" % next(self._session_ids)
             session = Session(
                 session_id=session_id, process=process, pid=pid, name=name
@@ -237,7 +244,7 @@ class SessionStore:
             dead = [
                 session_id
                 for session_id, session in self._sessions.items()
-                if not _looks_alive(session.pid)
+                if not looks_alive(session.pid)
             ]
 
         for session_id in dead:
@@ -246,10 +253,6 @@ class SessionStore:
             except SessionError:  # closed concurrently
                 pass
         return dead
-
-    def is_alive(self, session_id: str) -> bool:
-        """Whether this session's target still exists."""
-        return _looks_alive(self.get(session_id).pid)
 
     def capacity_refusal(self, pid: int = 0) -> Optional[str]:
         """The reason :meth:`open` would refuse right now, or ``None``.
@@ -271,40 +274,51 @@ class SessionStore:
         self._reap_dead()
 
         with self._lock:
-            if len(self._sessions) < MAX_OPEN_SESSIONS:
-                return None
+            return self._refusal_locked(pid)
 
-            # No "close the oldest": the oldest is usually the target the whole
-            # session has been refining, and close_process discards its scan
-            # results too. The list is given instead, so the choice is made on
-            # what each session holds.
-            existing = [
-                sid for sid, session in self._sessions.items()
-                if session.pid == pid
-            ]
-            already = (
-                " Note that pid %d is already open as %s — reuse that id "
-                "rather than attaching again." % (pid, existing[0])
-                if existing
-                else ""
+    def _refusal_locked(self, pid: int) -> Optional[str]:
+        """Render the refusal, or ``None``. **Caller holds** ``self._lock``.
+
+        Separate from :meth:`capacity_refusal` so :meth:`open` can check and
+        insert under one acquisition. When the check released the lock and the
+        insert took it again, the cap could be exceeded: every thread saw room,
+        then every thread inserted. Demonstrated with 12 concurrent opens
+        against a cap of 8.
+        """
+        if len(self._sessions) < MAX_OPEN_SESSIONS:
+            return None
+
+        # No "close the oldest": the oldest is usually the target the whole
+        # session has been refining, and close_process discards its scan
+        # results too. The list is given instead, so the choice is made on
+        # what each session holds.
+        existing = [
+            sid for sid, session in self._sessions.items()
+            if session.pid == pid
+        ]
+        already = (
+            " Note that pid %d is already open as %s — reuse that id "
+            "rather than attaching again." % (pid, existing[0])
+            if existing
+            else ""
+        )
+        return (
+            "This server already has %d processes open, which is the "
+            "limit, and all of them are live. Close whichever you are "
+            "done with (close_process also discards that session's scan "
+            "results) and attach again. Open: %s.%s"
+            % (
+                MAX_OPEN_SESSIONS,
+                ", ".join(
+                    "%s (%s, pid %d, %d scan%s)"
+                    % (sid, session.name or "?", session.pid,
+                       len(session.scan_ids),
+                       "" if len(session.scan_ids) == 1 else "s")
+                    for sid, session in self._sessions.items()
+                ),
+                already,
             )
-            return (
-                "This server already has %d processes open, which is the "
-                "limit, and all of them are live. Close whichever you are "
-                "done with (close_process also discards that session's scan "
-                "results) and attach again. Open: %s.%s"
-                % (
-                    MAX_OPEN_SESSIONS,
-                    ", ".join(
-                        "%s (%s, pid %d, %d scan%s)"
-                        % (sid, session.name or "?", session.pid,
-                           len(session.scan_ids),
-                           "" if len(session.scan_ids) == 1 else "s")
-                        for sid, session in self._sessions.items()
-                    ),
-                    already,
-                )
-            )
+        )
 
     def at_capacity(self) -> bool:
         """Whether :meth:`open` would refuse right now."""
@@ -501,6 +515,7 @@ def host_platform() -> str:
 
 __all__ = (
     "MAX_OPEN_SESSIONS",
+    "looks_alive",
     "MAX_SCANS_PER_SESSION",
     "ScanResult",
     "Session",

--- a/PyMemoryEditor/mcp/session.py
+++ b/PyMemoryEditor/mcp/session.py
@@ -32,6 +32,7 @@ from time import time
 from typing import Dict, List, Optional, Sequence, Tuple
 
 from ..process.abstract import AbstractProcess
+from ..process.util import pid_exists
 from ..process.region import MemoryRegion, MemoryRegionSnapshot
 
 
@@ -168,6 +169,22 @@ class Session:
         return tuple(self._scan_order)
 
 
+def _looks_alive(pid: int) -> bool:
+    """``pid_exists``, but a pid the OS will not even accept reads as dead.
+
+    The reaper runs inside ``open``, so anything raised here escapes as
+    something other than a ``SessionError`` and the model is told only
+    "Error executing tool". ``pid_exists(2**31)`` raises ``OverflowError``
+    (the value does not fit the platform's pid type), which the argument
+    fuzzer found by generating exactly that. A number the OS refuses cannot
+    name a running process, so treating it as dead is both safe and correct.
+    """
+    try:
+        return pid_exists(pid)
+    except (OverflowError, ValueError, OSError):
+        return False
+
+
 class SessionStore:
     """The server's process handles and their scan results.
 
@@ -189,20 +206,39 @@ class SessionStore:
         :raises SessionError: if :data:`MAX_OPEN_SESSIONS` are already open.
             The caller owns the handle it passed in and must close it.
         """
+        if len(self._sessions) >= MAX_OPEN_SESSIONS:
+            self._reap_dead()
+
         with self._lock:
             if len(self._sessions) >= MAX_OPEN_SESSIONS:
+                # No "close the oldest": the oldest is usually the target the
+                # whole session has been refining, and close_process discards
+                # its scan results too. The list is given instead, so the
+                # choice is made on what each session holds.
+                existing = [
+                    sid for sid, s in self._sessions.items() if s.pid == pid
+                ]
+                already = (
+                    " Note that pid %d is already open as %s — reuse that id "
+                    "rather than attaching again." % (pid, existing[0])
+                    if existing
+                    else ""
+                )
                 raise SessionError(
                     "This server already has %d processes open, which is the "
-                    "limit. Close one you are done with — close_process(%s) "
-                    "frees the oldest — and attach again. Open sessions: %s."
+                    "limit, and all of them are live. Close whichever you are "
+                    "done with (close_process also discards that session's "
+                    "scan results) and attach again. Open: %s.%s"
                     % (
                         MAX_OPEN_SESSIONS,
-                        next(iter(self._sessions)),
                         ", ".join(
-                            "%s (%s, pid %d)"
-                            % (sid, session.name or "?", session.pid)
+                            "%s (%s, pid %d, %d scan%s)"
+                            % (sid, session.name or "?", session.pid,
+                               len(session.scan_ids),
+                               "" if len(session.scan_ids) == 1 else "s")
                             for sid, session in self._sessions.items()
                         ),
+                        already,
                     )
                 )
 
@@ -213,6 +249,39 @@ class SessionStore:
             self._sessions[session_id] = session
             return session
 
+    def _reap_dead(self) -> List[str]:
+        """Drop sessions whose target no longer exists. Caller holds no lock.
+
+        The cap refuses rather than evicting, because closing a live handle
+        out from under the model is something it cannot detect. A *dead*
+        target is the exception that proves the rule: the handle is already
+        useless, so dropping it takes nothing away — and without this, eight
+        exited processes hold every slot forever and `open_process` is refused
+        for the rest of the server's life, with no way for the model to find
+        out which sessions are the dead ones (`process_info` answers happily
+        from cached state).
+
+        A recycled pid reads as alive, which is inherent to asking the OS by
+        number.
+        """
+        with self._lock:
+            dead = [
+                session_id
+                for session_id, session in self._sessions.items()
+                if not _looks_alive(session.pid)
+            ]
+
+        for session_id in dead:
+            try:
+                self.close(session_id)
+            except SessionError:  # closed concurrently
+                pass
+        return dead
+
+    def is_alive(self, session_id: str) -> bool:
+        """Whether this session's target still exists."""
+        return _looks_alive(self.get(session_id).pid)
+
     def at_capacity(self) -> bool:
         """Whether :meth:`open` would refuse right now.
 
@@ -221,7 +290,16 @@ class SessionStore:
         since spending an approval on an attach that cannot happen is worse
         than refusing outright. :meth:`open` stays the authority: this is a
         hint, and the two can differ under a concurrent open.
+
+        Reaps first, or this would report a server full of exited processes as
+        full when `open` would have made room.
         """
+        with self._lock:
+            if len(self._sessions) < MAX_OPEN_SESSIONS:
+                return False
+
+        self._reap_dead()
+
         with self._lock:
             return len(self._sessions) >= MAX_OPEN_SESSIONS
 

--- a/PyMemoryEditor/mcp/session.py
+++ b/PyMemoryEditor/mcp/session.py
@@ -213,6 +213,18 @@ class SessionStore:
             self._sessions[session_id] = session
             return session
 
+    def at_capacity(self) -> bool:
+        """Whether :meth:`open` would refuse right now.
+
+        Lets a caller fail before doing something expensive that the refusal
+        would waste — the protocol layer asks this before prompting the user,
+        since spending an approval on an attach that cannot happen is worse
+        than refusing outright. :meth:`open` stays the authority: this is a
+        hint, and the two can differ under a concurrent open.
+        """
+        with self._lock:
+            return len(self._sessions) >= MAX_OPEN_SESSIONS
+
     def get(self, session_id: str) -> Session:
         """Look up a session, or explain how to obtain a valid id."""
         known = "none"

--- a/PyMemoryEditor/mcp/session.py
+++ b/PyMemoryEditor/mcp/session.py
@@ -226,8 +226,12 @@ class SessionStore:
                     self._sessions[session_id] = session
                     return session
 
-            if reaped:
-                raise SessionError(refusal)
+                if reaped:
+                    # Raised here, not after the block: computing the refusal
+                    # under the lock and raising it outside leaves a window
+                    # where another thread closes a session, and this caller
+                    # is turned away with a message that is already false.
+                    raise SessionError(refusal)
 
             # Outside the lock: reaping closes handles, which takes it again.
             self._reap_dead()

--- a/PyMemoryEditor/mcp/toolset.py
+++ b/PyMemoryEditor/mcp/toolset.py
@@ -38,7 +38,7 @@ from ..enums import ScanTypesEnum
 from ..process.abstract import AbstractProcess
 from ..process.errors import PyMemoryEditorError
 from ..process.region import MemoryRegion
-from ..process.util import get_process_ids_by_name, iter_processes, pid_exists
+from ..process.util import get_process_ids_by_name, iter_processes
 from ..util import (
     decode_scan_target,
     resolve_bufflength,
@@ -56,6 +56,7 @@ from .session import (
     SessionStore,
     batch_regions,
     host_platform,
+    looks_alive,
     region_to_dict,
 )
 
@@ -567,7 +568,12 @@ class MemoryToolset:
                 "pid": session.pid,
                 "name": session.name,
                 "scan_ids": list(session.scan_ids),
-                "alive": pid_exists(session.pid),
+                # `looks_alive`, not `pid_exists`: the raw call raises
+                # OverflowError for a pid outside the platform's range, and
+                # server_info is the tool the instructions tell the model to
+                # call first — a crash here hides the limits and the policy
+                # too, not just this field.
+                "alive": looks_alive(session.pid),
             }
             for session in self.store.sessions
         ]

--- a/PyMemoryEditor/mcp/toolset.py
+++ b/PyMemoryEditor/mcp/toolset.py
@@ -48,8 +48,11 @@ from ..util import (
 )
 from .config import ServerConfig
 from .session import (
+    MAX_OPEN_SESSIONS,
+    MAX_SCANS_PER_SESSION,
     ScanResult,
     Session,
+    SessionError,
     SessionStore,
     batch_regions,
     host_platform,
@@ -599,6 +602,8 @@ class MemoryToolset:
                 # to.
                 "max_address": format_address(MAX_ADDRESS),
                 "max_offset_magnitude": format_address(MAX_OFFSET_MAGNITUDE),
+                "max_open_sessions": MAX_OPEN_SESSIONS,
+                "max_scans_per_session": MAX_SCANS_PER_SESSION,
             },
             "open_sessions": sessions,
         }
@@ -771,7 +776,17 @@ class MemoryToolset:
                 "Could not open pid %d: %s. %s" % (pid, error, _permission_hint())
             ) from None
 
-        session = self.store.open(process, pid, name)
+        try:
+            session = self.store.open(process, pid, name)
+        except SessionError:
+            # The handle already exists and the store's cap is checked after
+            # it does, so refusing without closing leaks the resource the cap
+            # protects.
+            try:
+                process.close()
+            except Exception:  # noqa: BLE001 — target may already be gone
+                pass
+            raise
 
         result: Dict[str, Any] = {
             "opened": True,
@@ -796,6 +811,10 @@ class MemoryToolset:
         ``close_process`` or server shutdown; reuse its id rather than
         reopening the same target, since each open costs a handle and resets
         the cached region map.
+
+        At most ``max_open_sessions`` (see ``server_info``) can be open at
+        once; reaching it is refused, not rotated, so ``close_process`` a
+        target you are done with.
 
         Attaching to a process the operator has not pre-approved requires the
         **user's** approval, asked for at the moment you call this. Say which

--- a/PyMemoryEditor/mcp/toolset.py
+++ b/PyMemoryEditor/mcp/toolset.py
@@ -38,7 +38,7 @@ from ..enums import ScanTypesEnum
 from ..process.abstract import AbstractProcess
 from ..process.errors import PyMemoryEditorError
 from ..process.region import MemoryRegion
-from ..process.util import get_process_ids_by_name, iter_processes
+from ..process.util import get_process_ids_by_name, iter_processes, pid_exists
 from ..util import (
     decode_scan_target,
     resolve_bufflength,
@@ -556,12 +556,18 @@ class MemoryToolset:
         reachable, how long a scan may run, and which sessions are already
         open from earlier in the conversation.
         """
+        # `alive` because a session outlives its target: nothing here notices
+        # a process exiting, `process_info` keeps answering from cached state,
+        # and the open-session cap means dead ones would hold slots the model
+        # cannot identify. The store reaps them when it needs room; this is how
+        # the model sees them before that.
         sessions = [
             {
                 "session_id": session.session_id,
                 "pid": session.pid,
                 "name": session.name,
                 "scan_ids": list(session.scan_ids),
+                "alive": pid_exists(session.pid),
             }
             for session in self.store.sessions
         ]
@@ -2020,7 +2026,8 @@ class MemoryToolset:
         """Yield ``(address, value | None)`` for each address, in one pass.
 
         Uses ``search_by_addresses``, which groups the reads by region so a
-        50 000-address refine is a few hundred syscalls rather than 50 000.
+        refine of a capped result set is a few hundred syscalls rather than one
+        per address.
         """
         yield from session.process.search_by_addresses(
             pytype,

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -111,7 +111,7 @@ pymemoryeditor-mcp --allow-any-process        # never asks at all (scripts/CI)
 </tr>
 <tr>
   <td><code>--max-scan-results N</code></td>
-  <td>Addresses one scan may keep. Default 50 000.</td>
+  <td>Addresses one scan may keep. Default 100 000.</td>
 </tr>
 <tr>
   <td><code>--max-scan-seconds S</code></td>
@@ -129,7 +129,7 @@ pymemoryeditor-mcp --allow-any-process        # never asks at all (scripts/CI)
 <tr><th width="30%">Tool</th><th>What it does</th></tr>
 <tr><td><code>server_info</code></td><td>Capabilities, limits, policy and open sessions. The assistant should call this first.</td></tr>
 <tr><td><code>list_processes</code></td><td>Running processes the server is allowed to open.</td></tr>
-<tr><td><code>open_process</code></td><td>Attach by pid or name → a <code>session_id</code>.</td></tr>
+<tr><td><code>open_process</code></td><td>Attach by pid or name → a <code>session_id</code>. Eight targets can be open at once; past that it refuses rather than rotating one out, since a handle the assistant still holds must not vanish under it.</td></tr>
 <tr><td><code>close_process</code></td><td>Detach and drop that session's scan results.</td></tr>
 <tr><td><code>process_info</code></td><td>Bitness, address-space summary, modules and threads.</td></tr>
 <tr><td><code>list_memory_regions</code></td><td>Page through the memory map, filtered by permission or backing file.</td></tr>

--- a/tests/mcp_server/test_parsing.py
+++ b/tests/mcp_server/test_parsing.py
@@ -630,6 +630,47 @@ class TestTheTwoCoverageConfigsPartitionThePackage:
         assert len(lib) + len(mcp) > len(sources) // 2
 
 
+class TestTheDocsQuoteTheRealLimits:
+    """`docs/mcp.md` spells the caps out as words, which a reader wants and a
+    constant change silently invalidates. Same guard as
+    `test_advertised_widths_are_exactly_the_accepted_widths`."""
+
+    WORDS = {
+        1: "one", 2: "two", 3: "three", 4: "four", 5: "five",
+        6: "six", 7: "seven", 8: "eight", 9: "nine", 10: "ten",
+    }
+
+    def _mcp_doc(self):
+        from pathlib import Path
+
+        return (
+            Path(__file__).resolve().parents[2] / "docs" / "mcp.md"
+        ).read_text(encoding="utf-8")
+
+    def test_the_open_session_cap_matches_the_constant(self):
+        from PyMemoryEditor.mcp.session import MAX_OPEN_SESSIONS
+
+        doc = self._mcp_doc().lower()
+        word = self.WORDS[MAX_OPEN_SESSIONS]
+
+        assert "%s targets can be open at once" % word in doc, (
+            "docs/mcp.md does not state MAX_OPEN_SESSIONS=%d (%r)"
+            % (MAX_OPEN_SESSIONS, word)
+        )
+
+    def test_the_scan_result_cap_matches_the_default(self):
+        from PyMemoryEditor.mcp.config import DEFAULT_MAX_SCAN_RESULTS
+
+        doc = self._mcp_doc()
+        # The docs group digits, as prose should: "100 000", not "100000".
+        grouped = "{:,}".format(DEFAULT_MAX_SCAN_RESULTS).replace(",", " ")
+
+        assert "Default %s." % grouped in doc, (
+            "docs/mcp.md does not state DEFAULT_MAX_SCAN_RESULTS=%s"
+            % grouped
+        )
+
+
 class TestServerConfigValidatesItsBounds:
     """The three numeric bounds were checked at the CLI only.
 

--- a/tests/mcp_server/test_parsing.py
+++ b/tests/mcp_server/test_parsing.py
@@ -650,10 +650,18 @@ class TestTheDocsQuoteTheRealLimits:
     def test_the_open_session_cap_matches_the_constant(self):
         from PyMemoryEditor.mcp.session import MAX_OPEN_SESSIONS
 
-        doc = self._mcp_doc().lower()
-        word = self.WORDS[MAX_OPEN_SESSIONS]
+        # Looked up, not indexed. This test exists to turn a silent doc/code
+        # divergence into an actionable message, and `WORDS[12]` would have
+        # replaced that with `KeyError: 12` — loud, but saying nothing about
+        # what to do.
+        word = self.WORDS.get(MAX_OPEN_SESSIONS)
+        assert word is not None, (
+            "MAX_OPEN_SESSIONS is %d and WORDS has no spelling for it. Add "
+            "one, then update the open_process row in docs/mcp.md to match."
+            % MAX_OPEN_SESSIONS
+        )
 
-        assert "%s targets can be open at once" % word in doc, (
+        assert "%s targets can be open at once" % word in self._mcp_doc().lower(), (
             "docs/mcp.md does not state MAX_OPEN_SESSIONS=%d (%r)"
             % (MAX_OPEN_SESSIONS, word)
         )

--- a/tests/mcp_server/test_server.py
+++ b/tests/mcp_server/test_server.py
@@ -437,11 +437,15 @@ class TestAttachApproval:
         assert "did not approve" in text
         assert "Do not retry" in text
 
-    def test_a_full_server_refuses_before_spending_an_approval(self):
+    def test_a_full_server_refuses_before_spending_an_approval(self, monkeypatch):
         """The cap lives in `SessionStore.open`, which runs after the handle is
         already open — so the user used to be asked, approve, and only then be
         told the server was full."""
+        from PyMemoryEditor.mcp import session as session_module
         from PyMemoryEditor.mcp.session import MAX_OPEN_SESSIONS
+
+        # Fakes carry arbitrary pids, which the store's reaper reads as dead.
+        monkeypatch.setattr(session_module, "pid_exists", lambda pid: True)
 
         server, toolset, _process = self._build(ServerConfig())
         for _ in range(MAX_OPEN_SESSIONS):
@@ -459,9 +463,13 @@ class TestAttachApproval:
         assert answerer.asked is False, "the user was prompted for an attach that could not happen"
         assert "close_process" in result.content[0].text
 
-    def test_the_refusal_names_the_target_it_declined(self):
+    def test_the_refusal_names_the_target_it_declined(self, monkeypatch):
         """A model reads this and must not conclude the pid was the problem."""
+        from PyMemoryEditor.mcp import session as session_module
         from PyMemoryEditor.mcp.session import MAX_OPEN_SESSIONS
+
+        # Fakes carry arbitrary pids, which the store's reaper reads as dead.
+        monkeypatch.setattr(session_module, "pid_exists", lambda pid: True)
 
         server, toolset, _process = self._build(ServerConfig())
         for _ in range(MAX_OPEN_SESSIONS):

--- a/tests/mcp_server/test_server.py
+++ b/tests/mcp_server/test_server.py
@@ -482,6 +482,32 @@ class TestAttachApproval:
         text = asyncio.run(run()).content[0].text
         assert "faketarget" in text and "4242" in text
         assert str(MAX_OPEN_SESSIONS) in text
+        # The early path renders the store's message, so it is as actionable
+        # as the late one: every open session, with its scan count.
+        assert "proc-1" in text and "scan" in text
+
+    def test_an_unnamed_target_is_not_refused_as_an_empty_string(self, monkeypatch):
+        """`_name_for_pid` returns "" for a pid missing from the listing.
+
+        The elicitation prompt below this already guards with `or "unknown"`;
+        the refusal did not, so it rendered `attach to "" (pid 4242)`.
+        """
+        from PyMemoryEditor.mcp import session as session_module
+        from PyMemoryEditor.mcp.session import MAX_OPEN_SESSIONS
+
+        monkeypatch.setattr(session_module, "pid_exists", lambda pid: True)
+        server, toolset, _process = self._build(ServerConfig())
+        monkeypatch.setattr(toolset, "_name_for_pid", lambda pid: "")
+        for _ in range(MAX_OPEN_SESSIONS):
+            toolset.store.open(FakeProcess(), 4242, "faketarget")
+
+        async def run():
+            async with connected(server, Answerer("accept")) as session:
+                return await session.call_tool("open_process", {"pid": 4242})
+
+        text = asyncio.run(run()).content[0].text
+        assert 'attach to ""' not in text
+        assert "unknown" in text
 
     def test_cancelling_the_dialog_is_not_approval(self):
         result, toolset = self._open(ServerConfig(), Answerer("cancel"))

--- a/tests/mcp_server/test_server.py
+++ b/tests/mcp_server/test_server.py
@@ -437,6 +437,44 @@ class TestAttachApproval:
         assert "did not approve" in text
         assert "Do not retry" in text
 
+    def test_a_full_server_refuses_before_spending_an_approval(self):
+        """The cap lives in `SessionStore.open`, which runs after the handle is
+        already open — so the user used to be asked, approve, and only then be
+        told the server was full."""
+        from PyMemoryEditor.mcp.session import MAX_OPEN_SESSIONS
+
+        server, toolset, _process = self._build(ServerConfig())
+        for _ in range(MAX_OPEN_SESSIONS):
+            toolset.store.open(FakeProcess(), 4242, "faketarget")
+
+        answerer = Answerer("accept")
+
+        async def run():
+            async with connected(server, answerer) as session:
+                return await session.call_tool("open_process", {"pid": 4242})
+
+        result = asyncio.run(run())
+
+        assert result.is_error is True
+        assert answerer.asked is False, "the user was prompted for an attach that could not happen"
+        assert "close_process" in result.content[0].text
+
+    def test_the_refusal_names_the_target_it_declined(self):
+        """A model reads this and must not conclude the pid was the problem."""
+        from PyMemoryEditor.mcp.session import MAX_OPEN_SESSIONS
+
+        server, toolset, _process = self._build(ServerConfig())
+        for _ in range(MAX_OPEN_SESSIONS):
+            toolset.store.open(FakeProcess(), 4242, "faketarget")
+
+        async def run():
+            async with connected(server, Answerer("accept")) as session:
+                return await session.call_tool("open_process", {"pid": 4242})
+
+        text = asyncio.run(run()).content[0].text
+        assert "faketarget" in text and "4242" in text
+        assert str(MAX_OPEN_SESSIONS) in text
+
     def test_cancelling_the_dialog_is_not_approval(self):
         result, toolset = self._open(ServerConfig(), Answerer("cancel"))
         assert result.is_error is True

--- a/tests/mcp_server/test_session.py
+++ b/tests/mcp_server/test_session.py
@@ -235,19 +235,19 @@ class TestOpenSessionsAreCapped:
                for _ in range(MAX_OPEN_SESSIONS)]
 
         store.close(ids[0])
-        reaberto = store.open(FakeProcess(), 2, "b")
+        reopened = store.open(FakeProcess(), 2, "b")
 
-        assert reaberto.session_id not in ids
+        assert reopened.session_id not in ids
         assert len(store.sessions) == MAX_OPEN_SESSIONS
 
     def test_ids_keep_climbing_after_a_close(self, store):
         """Reusing an id would let a model holding a stale one address a
         different process."""
-        primeiro = store.open(FakeProcess(), 1, "a").session_id
-        store.close(primeiro)
-        segundo = store.open(FakeProcess(), 2, "b").session_id
+        first = store.open(FakeProcess(), 1, "a").session_id
+        store.close(first)
+        second = store.open(FakeProcess(), 2, "b").session_id
 
-        assert primeiro != segundo
+        assert first != second
 
 
 class TestBatchRegions:

--- a/tests/mcp_server/test_session.py
+++ b/tests/mcp_server/test_session.py
@@ -327,6 +327,37 @@ class TestTheCapHoldsUnderConcurrency:
         with pytest.raises(AssertionError):
             store._refusal_locked(0)
 
+    def test_the_refusal_is_raised_inside_the_critical_section(
+        self, store, all_alive, monkeypatch
+    ):
+        """Deciding under the lock and raising outside it leaves a window.
+
+        Another thread can close a session in that gap, so the caller is turned
+        away with a message that is already false — the store has room by the
+        time it reads it. Probed by recording whether the lock was held at the
+        moment the error was constructed.
+        """
+        for _ in range(MAX_OPEN_SESSIONS):
+            store.open(FakeProcess(), 1, "a")
+
+        held = []
+        original = session_module.SessionError
+
+        class Probe(original):  # type: ignore[misc, valid-type]
+            def __init__(self, *args):
+                held.append(store._lock.locked())
+                super().__init__(*args)
+
+        monkeypatch.setattr(session_module, "SessionError", Probe)
+
+        with pytest.raises(original):
+            store.open(FakeProcess(), 2, "b")
+
+        assert held == [True], (
+            "the refusal was built after the lock was released, so the store "
+            "may already have had room"
+        )
+
     def test_open_judges_and_inserts_under_one_acquisition(self, all_alive):
         """The assertion above is not enough on its own.
 

--- a/tests/mcp_server/test_session.py
+++ b/tests/mcp_server/test_session.py
@@ -7,6 +7,7 @@ Handle bookkeeping: sessions, scan result sets, and the region batching.
 import pytest
 
 from PyMemoryEditor.mcp.session import (
+    MAX_OPEN_SESSIONS,
     MAX_SCANS_PER_SESSION,
     SessionError,
     SessionStore,
@@ -201,6 +202,54 @@ class TestRegionSnapshotCaching:
         )
 
 
+class TestOpenSessionsAreCapped:
+    """The store used to accept any number of open processes, each holding an
+    OS handle that only `close_process` releases."""
+
+    def test_the_cap_is_enforced(self, store):
+        for _ in range(MAX_OPEN_SESSIONS):
+            store.open(FakeProcess(), 1, "a")
+
+        with pytest.raises(SessionError) as error:
+            store.open(FakeProcess(), 1, "a")
+
+        assert str(MAX_OPEN_SESSIONS) in str(error.value)
+
+    def test_the_refusal_says_how_to_recover(self, store):
+        """The model cannot see the store, so the message has to name an id to
+        close and list what is open."""
+        for index in range(MAX_OPEN_SESSIONS):
+            store.open(FakeProcess(pid=100 + index), 100 + index, "target%d" % index)
+
+        with pytest.raises(SessionError) as error:
+            store.open(FakeProcess(), 999, "another")
+
+        message = str(error.value)
+        assert "close_process" in message
+        assert "proc-1" in message          # the id it is told to close
+        assert "target0" in message         # and what is actually open
+        assert "pid 100" in message
+
+    def test_closing_one_frees_a_slot(self, store):
+        ids = [store.open(FakeProcess(), 1, "a").session_id
+               for _ in range(MAX_OPEN_SESSIONS)]
+
+        store.close(ids[0])
+        reaberto = store.open(FakeProcess(), 2, "b")
+
+        assert reaberto.session_id not in ids
+        assert len(store.sessions) == MAX_OPEN_SESSIONS
+
+    def test_ids_keep_climbing_after_a_close(self, store):
+        """Reusing an id would let a model holding a stale one address a
+        different process."""
+        primeiro = store.open(FakeProcess(), 1, "a").session_id
+        store.close(primeiro)
+        segundo = store.open(FakeProcess(), 2, "b").session_id
+
+        assert primeiro != segundo
+
+
 class TestBatchRegions:
     def _regions(self, sizes):
         address = 0x1000
@@ -221,28 +270,18 @@ class TestBatchRegions:
         assert len(batches) == 4  # 3 x 300 bytes, then the 100-byte remainder
 
     def test_a_region_larger_than_the_budget_gets_its_own_batch(self):
-        # It cannot be split without splitting a value across the seam, so the
-        # budget is a target rather than a guarantee -- but the batch that
-        # busts it should not be carrying anything else.
-        #
-        # This assertion used to be `[2, 1]`, i.e. the oversized region shared
-        # a batch with the small one before it, under this same name. The name
-        # was right and the assertion pinned the opposite, so the test was
-        # documenting the bug it looked like it was guarding against.
+        # A region can't be split without splitting a value across the seam,
+        # so the budget is a target -- but the batch that busts it should not
+        # carry anything else. This asserted `[2, 1]` under the same name,
+        # i.e. it pinned the opposite of what the name claims.
         batches = batch_regions(self._regions([10, 5000, 10]), 100)
         assert [[region.size for region in batch] for batch in batches] == [
             [10], [5000], [10]
         ]
 
     def test_a_run_of_small_regions_does_not_ride_along_with_a_large_one(self):
-        """The case that made the deadline check pointless.
-
-        `batch_regions` exists so `_run_batched_scan` gets a chance to look at
-        the clock between batches. Without the flush, every small region before
-        an oversized one joined it: `[10, 10, 10, 5000]` against a 100-byte
-        budget came back as a *single* batch of four, so the deadline was
-        checked once for the whole scan -- the one thing the batching is for.
-        """
+        """Without the flush, `[10, 10, 10, 5000]` on a 100-byte budget was one
+        batch of four, so the deadline was checked once for the whole scan."""
         batches = batch_regions(self._regions([10, 10, 10, 5000]), 100)
 
         assert len(batches) == 2

--- a/tests/mcp_server/test_session.py
+++ b/tests/mcp_server/test_session.py
@@ -268,6 +268,81 @@ class TestOpenSessionsAreCapped:
         assert first != second
 
 
+class TestTheCapHoldsUnderConcurrency:
+    """Tool calls run on a thread pool, so `open` races with itself.
+
+    A refactor split the capacity check and the insert across two acquisitions
+    of the store's lock: every thread saw room, then every thread inserted.
+    The window is a few bytecodes wide, so it does not reproduce on its own —
+    hence the injected pause, which makes a structural defect observable
+    instead of waiting for luck.
+    """
+
+    def test_the_cap_is_not_exceeded_when_opens_race(self, store, all_alive):
+        import threading
+
+        start = threading.Barrier(MAX_OPEN_SESSIONS * 2)
+
+        def attach():
+            start.wait()
+            try:
+                store.open(FakeProcess(), 1, "a")
+            except SessionError:
+                pass
+
+        threads = [
+            threading.Thread(target=attach)
+            for _ in range(MAX_OPEN_SESSIONS * 2)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert len(store.sessions) == MAX_OPEN_SESSIONS
+
+    def test_the_cap_holds_even_with_the_window_stretched(
+        self, store, all_alive, monkeypatch
+    ):
+        """The same property with the race window made wide enough to lose.
+
+        Without this, the test above passes on a broken implementation: the
+        gap between check and insert is too narrow for the scheduler to land
+        in reliably.
+        """
+        import threading
+        import time
+
+        original = type(store).capacity_refusal
+
+        def slow(self, pid=0):
+            result = original(self, pid)
+            time.sleep(0.02)
+            return result
+
+        monkeypatch.setattr(type(store), "capacity_refusal", slow)
+
+        start = threading.Barrier(MAX_OPEN_SESSIONS + 4)
+
+        def attach():
+            start.wait()
+            try:
+                store.open(FakeProcess(), 1, "a")
+            except SessionError:
+                pass
+
+        threads = [
+            threading.Thread(target=attach)
+            for _ in range(MAX_OPEN_SESSIONS + 4)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert len(store.sessions) == MAX_OPEN_SESSIONS
+
+
 class TestDeadSessionsDoNotHoldSlots:
     """The lockout the cap created, and the reason it evicts here but nowhere
     else.
@@ -328,9 +403,9 @@ class TestDeadSessionsDoNotHoldSlots:
         exactly that. Intermittently, because it also needed the store to be
         at capacity at that moment.
         """
-        from PyMemoryEditor.mcp.session import _looks_alive
+        from PyMemoryEditor.mcp.session import looks_alive
 
-        assert _looks_alive(pid) is False
+        assert looks_alive(pid) is False
 
         for index in range(MAX_OPEN_SESSIONS):
             store.open(FakeProcess(pid=pid), pid, "weird%d" % index)

--- a/tests/mcp_server/test_session.py
+++ b/tests/mcp_server/test_session.py
@@ -10,6 +10,7 @@ from PyMemoryEditor.mcp import session as session_module
 from PyMemoryEditor.mcp.session import (
     MAX_OPEN_SESSIONS,
     MAX_SCANS_PER_SESSION,
+    Session,
     SessionError,
     SessionStore,
     batch_regions,
@@ -301,46 +302,103 @@ class TestTheCapHoldsUnderConcurrency:
 
         assert len(store.sessions) == MAX_OPEN_SESSIONS
 
-    def test_the_cap_holds_even_with_the_window_stretched(
-        self, store, all_alive, monkeypatch
-    ):
-        """The same property with the race window made wide enough to lose.
+    def test_capacity_is_judged_while_the_lock_is_held(self, store, all_alive):
+        """The property the timing test could not actually probe.
 
-        Without this, the test above passes on a broken implementation: the
-        gap between check and insert is too narrow for the scheduler to land
-        in reliably.
+        A previous version of this test patched `capacity_refusal` and slept
+        in it to widen the race — but `open` calls `_refusal_locked`, not
+        `capacity_refusal`, so the sleep never fired and the test only
+        duplicated the one above. It passed its mutation check because that
+        mutant happened to reintroduce the `capacity_refusal` call.
+
+        Asserted structurally instead: `_refusal_locked` refuses to judge
+        capacity unless the lock is held, so splitting the check from the
+        insert fails deterministically rather than when the scheduler
+        cooperates.
+        """
+        for _ in range(MAX_OPEN_SESSIONS):
+            store.open(FakeProcess(), 1, "a")
+
+        # Held: this is how `open` calls it, and it answers.
+        with store._lock:
+            assert store._refusal_locked(0) is not None
+
+        # Not held: it refuses to answer at all.
+        with pytest.raises(AssertionError):
+            store._refusal_locked(0)
+
+    def test_open_judges_and_inserts_under_one_acquisition(self, all_alive):
+        """The assertion above is not enough on its own.
+
+        It only proves capacity is judged under *an* acquisition, not that the
+        same one covers the insert — a version that judged under its own lock,
+        released, and then took the lock again to insert passed it, and that is
+        exactly the regression this guards. Counting acquisitions separates
+        them: one for the correct implementation, two for the split.
         """
         import threading
-        import time
 
-        original = type(store).capacity_refusal
+        class CountingLock:
+            def __init__(self):
+                self._real = threading.Lock()
+                self.acquisitions = 0
 
-        def slow(self, pid=0):
-            result = original(self, pid)
-            time.sleep(0.02)
-            return result
+            def __enter__(self):
+                self.acquisitions += 1
+                return self._real.__enter__()
 
-        monkeypatch.setattr(type(store), "capacity_refusal", slow)
+            def __exit__(self, *exc):
+                return self._real.__exit__(*exc)
 
-        start = threading.Barrier(MAX_OPEN_SESSIONS + 4)
+            def locked(self):
+                return self._real.locked()
 
-        def attach():
-            start.wait()
-            try:
-                store.open(FakeProcess(), 1, "a")
-            except SessionError:
-                pass
+        store = SessionStore()
+        lock = CountingLock()
+        store._lock = lock
 
-        threads = [
-            threading.Thread(target=attach)
-            for _ in range(MAX_OPEN_SESSIONS + 4)
-        ]
-        for thread in threads:
-            thread.start()
-        for thread in threads:
-            thread.join()
+        store.open(FakeProcess(), 1, "a")
 
-        assert len(store.sessions) == MAX_OPEN_SESSIONS
+        assert lock.acquisitions == 1, (
+            "capacity and the insert must share one acquisition; %d means the "
+            "check released the lock before inserting" % lock.acquisitions
+        )
+
+    def test_a_dead_session_is_reaped_even_if_the_store_fills_meanwhile(
+        self, store, monkeypatch
+    ):
+        """`open` used to decide whether to reap from a check taken under an
+        earlier acquisition of the lock. If the store filled in between, it
+        refused without anyone having looked for a dead session.
+
+        Simulated by filling the store from inside the first check, which is
+        the same ordering a concurrent open produces.
+        """
+        alive = {4242}
+        monkeypatch.setattr(session_module, "pid_exists", lambda pid: pid in alive)
+
+        store.open(FakeProcess(pid=4242), 4242, "live")
+
+        original = type(store)._refusal_locked
+        calls = []
+
+        def fill_once(self, pid):
+            if not calls:
+                calls.append(pid)
+                for index in range(MAX_OPEN_SESSIONS - 1):
+                    session_id = "proc-%d" % next(self._session_ids)
+                    self._sessions[session_id] = Session(
+                        session_id=session_id, process=FakeProcess(pid=700 + index),
+                        pid=700 + index, name="gone%d" % index,
+                    )
+            return original(self, pid)
+
+        monkeypatch.setattr(type(store), "_refusal_locked", fill_once)
+
+        # Full at the moment of the check, but seven of the eight are dead.
+        session = store.open(FakeProcess(pid=4243), 4243, "second")
+
+        assert session.pid == 4243
 
 
 class TestDeadSessionsDoNotHoldSlots:

--- a/tests/mcp_server/test_session.py
+++ b/tests/mcp_server/test_session.py
@@ -6,6 +6,7 @@ Handle bookkeeping: sessions, scan result sets, and the region batching.
 
 import pytest
 
+from PyMemoryEditor.mcp import session as session_module
 from PyMemoryEditor.mcp.session import (
     MAX_OPEN_SESSIONS,
     MAX_SCANS_PER_SESSION,
@@ -202,11 +203,23 @@ class TestRegionSnapshotCaching:
         )
 
 
+@pytest.fixture
+def all_alive(monkeypatch):
+    """Pin every session's target as live.
+
+    The store reaps sessions whose pid is gone, and a fake's pid is an
+    arbitrary number — so without this these tests depend on the host's
+    process table, and the cap either fires or does not by luck. (Several
+    passed only because `pid_exists(1)` is true on a Unix host.)
+    """
+    monkeypatch.setattr(session_module, "pid_exists", lambda pid: True)
+
+
 class TestOpenSessionsAreCapped:
     """The store used to accept any number of open processes, each holding an
     OS handle that only `close_process` releases."""
 
-    def test_the_cap_is_enforced(self, store):
+    def test_the_cap_is_enforced(self, store, all_alive):
         for _ in range(MAX_OPEN_SESSIONS):
             store.open(FakeProcess(), 1, "a")
 
@@ -215,7 +228,7 @@ class TestOpenSessionsAreCapped:
 
         assert str(MAX_OPEN_SESSIONS) in str(error.value)
 
-    def test_the_refusal_says_how_to_recover(self, store):
+    def test_the_refusal_says_how_to_recover(self, store, all_alive):
         """The model cannot see the store, so the message has to name an id to
         close and list what is open."""
         for index in range(MAX_OPEN_SESSIONS):
@@ -226,11 +239,16 @@ class TestOpenSessionsAreCapped:
 
         message = str(error.value)
         assert "close_process" in message
-        assert "proc-1" in message          # the id it is told to close
-        assert "target0" in message         # and what is actually open
+        assert "proc-1" in message          # every open session is listed
+        assert "target0" in message
         assert "pid 100" in message
+        # No "close the oldest": the oldest is usually the target the whole
+        # session has been refining, and closing it discards its scans too.
+        assert "oldest" not in message
+        # The scan count is what makes the list actionable.
+        assert "scan" in message
 
-    def test_closing_one_frees_a_slot(self, store):
+    def test_closing_one_frees_a_slot(self, store, all_alive):
         ids = [store.open(FakeProcess(), 1, "a").session_id
                for _ in range(MAX_OPEN_SESSIONS)]
 
@@ -240,7 +258,7 @@ class TestOpenSessionsAreCapped:
         assert reopened.session_id not in ids
         assert len(store.sessions) == MAX_OPEN_SESSIONS
 
-    def test_ids_keep_climbing_after_a_close(self, store):
+    def test_ids_keep_climbing_after_a_close(self, store, all_alive):
         """Reusing an id would let a model holding a stale one address a
         different process."""
         first = store.open(FakeProcess(), 1, "a").session_id
@@ -248,6 +266,100 @@ class TestOpenSessionsAreCapped:
         second = store.open(FakeProcess(), 2, "b").session_id
 
         assert first != second
+
+
+class TestDeadSessionsDoNotHoldSlots:
+    """The lockout the cap created, and the reason it evicts here but nowhere
+    else.
+
+    Nothing in this server notices a target exiting: `_rows_for` swallows the
+    read error, `process_info` keeps answering from cached state, and the
+    session stays in the store. With a cap that refuses rather than evicts,
+    eight exited processes held every slot for the life of the server and the
+    model had no way to tell which sessions were the dead ones.
+
+    Evicting a *dead* session is the exception that proves the rule about not
+    evicting: its handle is already useless, so nothing is taken away.
+    """
+
+    def test_a_dead_session_is_reaped_to_make_room(self, store, monkeypatch):
+        for index in range(MAX_OPEN_SESSIONS):
+            store.open(FakeProcess(pid=500 + index), 500 + index, "gone%d" % index)
+
+        monkeypatch.setattr(session_module, "pid_exists", lambda pid: pid == 4242)
+
+        # Would have raised before the reaper existed.
+        session = store.open(FakeProcess(pid=4242), 4242, "live")
+
+        assert session.pid == 4242
+        assert [held.pid for held in store.sessions] == [4242], (
+            "the eight dead sessions should be gone, not merely joined"
+        )
+
+    def test_a_live_session_is_never_reaped(self, store, monkeypatch):
+        store.open(FakeProcess(pid=4242), 4242, "live")
+        for index in range(MAX_OPEN_SESSIONS - 1):
+            store.open(FakeProcess(pid=600 + index), 600 + index, "gone%d" % index)
+
+        monkeypatch.setattr(session_module, "pid_exists", lambda pid: pid == 4242)
+        store.open(FakeProcess(pid=4243), 4243, "second")
+
+        pids = sorted(s.pid for s in store.sessions)
+        assert 4242 in pids, "a live session was evicted"
+
+    def test_reaping_closes_the_handle(self, store, monkeypatch):
+        process = FakeProcess(pid=700)
+        store.open(process, 700, "gone")
+        monkeypatch.setattr(session_module, "pid_exists", lambda pid: False)
+
+        store._reap_dead()
+
+        assert process.closed is True, "the handle was dropped without closing"
+        assert store.sessions == ()
+
+    @pytest.mark.parametrize("pid", [2 ** 31, 2 ** 64, -3, 0])
+    def test_a_pid_the_os_refuses_reads_as_dead_not_as_a_crash(self, store, pid):
+        """The reaper runs inside `open`, so anything it raises escapes as
+        something other than SessionError and the model sees only "Error
+        executing tool".
+
+        `pid_exists(2**31)` raises OverflowError — the value does not fit the
+        platform's pid type — which the argument fuzzer found by generating
+        exactly that. Intermittently, because it also needed the store to be
+        at capacity at that moment.
+        """
+        from PyMemoryEditor.mcp.session import _looks_alive
+
+        assert _looks_alive(pid) is False
+
+        for index in range(MAX_OPEN_SESSIONS):
+            store.open(FakeProcess(pid=pid), pid, "weird%d" % index)
+
+        # Must not raise anything but SessionError, and here it makes room.
+        session = store.open(FakeProcess(pid=pid), pid, "another")
+        assert session.pid == pid
+
+    def test_a_full_server_of_live_targets_still_refuses(self, store, all_alive):
+        """The reaper must not become a back door around the cap."""
+        for index in range(MAX_OPEN_SESSIONS):
+            store.open(FakeProcess(pid=800 + index), 800 + index, "live%d" % index)
+
+        with pytest.raises(SessionError) as error:
+            store.open(FakeProcess(pid=900), 900, "another")
+
+        assert "all of them are live" in str(error.value)
+
+    def test_the_refusal_points_at_an_already_open_pid(self, store, all_alive):
+        """A model that lost count re-attaches instead of reusing the id."""
+        store.open(FakeProcess(pid=4242), 4242, "faketarget")
+        for index in range(MAX_OPEN_SESSIONS - 1):
+            store.open(FakeProcess(pid=810 + index), 810 + index, "other%d" % index)
+
+        with pytest.raises(SessionError) as error:
+            store.open(FakeProcess(pid=4242), 4242, "faketarget")
+
+        message = str(error.value)
+        assert "already open as proc-1" in message
 
 
 class TestBatchRegions:

--- a/tests/mcp_server/test_toolset.py
+++ b/tests/mcp_server/test_toolset.py
@@ -1221,15 +1221,23 @@ class TestThirdReviewRegressions:
         as well as the session list. The store had already been guarded for
         the same call; this file had not.
         """
+        # `os.getpid()`, not pid 1: Windows has no pid 1 (System Idle is 0,
+        # System is 4), so `pid_exists(1)` is False there and this test failed
+        # on that runner alone. The test's own process is alive by definition
+        # everywhere.
+        import os
+
+        alive_pid = os.getpid()
+
         toolset = make_toolset(config())
         toolset.store.open(FakeProcess(pid=2 ** 31), 2 ** 31, "impossible")
-        toolset.store.open(FakeProcess(pid=1), 1, "ordinary")
+        toolset.store.open(FakeProcess(pid=alive_pid), alive_pid, "ordinary")
 
         sessions = toolset.server_info()["open_sessions"]
 
         by_pid = {entry["pid"]: entry["alive"] for entry in sessions}
         assert by_pid[2 ** 31] is False
-        assert by_pid[1] is True
+        assert by_pid[alive_pid] is True
 
     def test_a_refused_attach_does_not_leak_the_handle(
         self, make_toolset, monkeypatch

--- a/tests/mcp_server/test_toolset.py
+++ b/tests/mcp_server/test_toolset.py
@@ -1215,7 +1215,12 @@ class TestThirdReviewRegressions:
     ):
         """`attach` opens the handle and *then* registers the session, so a
         refusal must close it or the cap leaks what it exists to bound."""
+        from PyMemoryEditor.mcp import session as session_module
         from PyMemoryEditor.mcp.session import MAX_OPEN_SESSIONS
+
+        # The store reaps sessions whose pid is gone, and a fake's pid is an
+        # arbitrary number, so the cap would never fire here otherwise.
+        monkeypatch.setattr(session_module, "pid_exists", lambda pid: True)
 
         opened = []
 

--- a/tests/mcp_server/test_toolset.py
+++ b/tests/mcp_server/test_toolset.py
@@ -1211,17 +1211,17 @@ class TestThirdReviewRegressions:
     # --- the one address no parser ever sees --------------------------- #
 
     def test_a_refused_attach_does_not_leak_the_handle(
-        self, make_toolset, fake_process, monkeypatch
+        self, make_toolset, monkeypatch
     ):
         """`attach` opens the handle and *then* registers the session, so a
         refusal must close it or the cap leaks what it exists to bound."""
         from PyMemoryEditor.mcp.session import MAX_OPEN_SESSIONS
 
-        abertos = []
+        opened = []
 
         def fake_open(**_kwargs):
             process = FakeProcess()
-            abertos.append(process)
+            opened.append(process)
             return process
 
         toolset = make_toolset(config())
@@ -1234,9 +1234,9 @@ class TestThirdReviewRegressions:
             toolset.open_process(pid=4242)
 
         # The last one is the refused attach's, and only it should be closed.
-        assert len(abertos) == MAX_OPEN_SESSIONS + 1
-        assert abertos[-1].closed is True
-        assert all(process.closed is False for process in abertos[:-1])
+        assert len(opened) == MAX_OPEN_SESSIONS + 1
+        assert opened[-1].closed is True
+        assert all(process.closed is False for process in opened[:-1])
 
     def test_a_chain_resolving_past_64_bits_is_refused_not_returned(
         self, make_toolset, fake_process

--- a/tests/mcp_server/test_toolset.py
+++ b/tests/mcp_server/test_toolset.py
@@ -1210,6 +1210,34 @@ class TestThirdReviewRegressions:
 
     # --- the one address no parser ever sees --------------------------- #
 
+    def test_a_refused_attach_does_not_leak_the_handle(
+        self, make_toolset, fake_process, monkeypatch
+    ):
+        """`attach` opens the handle and *then* registers the session, so a
+        refusal must close it or the cap leaks what it exists to bound."""
+        from PyMemoryEditor.mcp.session import MAX_OPEN_SESSIONS
+
+        abertos = []
+
+        def fake_open(**_kwargs):
+            process = FakeProcess()
+            abertos.append(process)
+            return process
+
+        toolset = make_toolset(config())
+        monkeypatch.setattr(toolset, "_open_process", fake_open)
+
+        for _ in range(MAX_OPEN_SESSIONS):
+            toolset.open_process(pid=4242)
+
+        with pytest.raises(SessionError):
+            toolset.open_process(pid=4242)
+
+        # The last one is the refused attach's, and only it should be closed.
+        assert len(abertos) == MAX_OPEN_SESSIONS + 1
+        assert abertos[-1].closed is True
+        assert all(process.closed is False for process in abertos[:-1])
+
     def test_a_chain_resolving_past_64_bits_is_refused_not_returned(
         self, make_toolset, fake_process
     ):

--- a/tests/mcp_server/test_toolset.py
+++ b/tests/mcp_server/test_toolset.py
@@ -1210,6 +1210,27 @@ class TestThirdReviewRegressions:
 
     # --- the one address no parser ever sees --------------------------- #
 
+    def test_server_info_survives_a_session_with_an_impossible_pid(
+        self, make_toolset
+    ):
+        """`server_info` is the tool the model is told to call first.
+
+        It rendered `alive` with a bare `pid_exists`, which raises
+        OverflowError for a pid outside the platform's range — so one odd
+        session took the whole result down, hiding the limits and the policy
+        as well as the session list. The store had already been guarded for
+        the same call; this file had not.
+        """
+        toolset = make_toolset(config())
+        toolset.store.open(FakeProcess(pid=2 ** 31), 2 ** 31, "impossible")
+        toolset.store.open(FakeProcess(pid=1), 1, "ordinary")
+
+        sessions = toolset.server_info()["open_sessions"]
+
+        by_pid = {entry["pid"]: entry["alive"] for entry in sessions}
+        assert by_pid[2 ** 31] is False
+        assert by_pid[1] is True
+
     def test_a_refused_attach_does_not_leak_the_handle(
         self, make_toolset, monkeypatch
     ):


### PR DESCRIPTION
Two changes to the MCP server's limits, one asked for and one the measurement turned up.

## `max_scan_results`: 50 000 → 100 000

Measured rather than estimated:

| | 50 000 | 100 000 | delta |
|---|---|---|---|
| Memory per result set | 2.1 MB | 4.2 MB | +2.1 MB |
| Worst case per session (20 sets) | 43 MB | 84 MB | +41 MB |
| `sort()` at the end of `_run_batched_scan` | 10.4 ms | 21.2 ms | +11 ms |
| Wall clock to reach the cap, real process | 0.02 s | 0.03 s | +10 ms |

Time is a non-issue: a value dense enough to hit the ceiling yields hits far
faster than the 30-second budget can spend, so the clock binds, not the cap.

The gain is narrow but it is correctness rather than convenience. A scan whose
true hit count falls between the two ceilings used to come back flagged
`partial`, and refining a truncated set can converge on an address that was
never in it. Above the new ceiling nothing changes — `int 0` matches millions
and is out of reach at any sane cap.

## `MAX_OPEN_SESSIONS`: new, 8

The measurement above is per session, which raised the question of how many
sessions there can be. The answer was: any number. Six opens of the same pid
gave six sessions, each with its own handle.

Nothing obliges a model to call `close_process`, and a forgotten session keeps
its handle until the server exits — a debug handle on Windows, a task port on
macOS. That is the one resource garbage collection cannot reclaim, so the
store is now bounded.

It **refuses rather than evicting**, unlike the per-session scan cap. Dropping
an old result set is safe because a refine loop never looks back; closing a
handle out from under the model is not, and it has no way to detect that. The
refusal names a session to close and lists what is open, since the model
cannot see the store.

### The naive version would have caused the problem it prevents

`attach` opens the handle and *then* registers the session. A store that
refuses at that point leaves the handle with nobody holding it, so every
rejected attach would have cost one more handle than having no cap at all.
`attach` now closes it before re-raising, with a test that fails without it.

## Also

`server_info` advertises `max_open_sessions` and `max_scans_per_session`, by
the principle already stated next to `max_text_bytes`: a limit this project
invented should not have to be discovered by tripping the error.

## Verification

Each guard mutation-tested by reverting it: the session cap (3 failures), the
handle close (1). 707 MCP tests, 91.4% coverage; 617 library tests, 87.2%;
`mypy` and `flake8` clean.