### PR TITLE
chore: bump version to 3.0.0

### DIFF
--- a/PyMemoryEditor/__init__.py
+++ b/PyMemoryEditor/__init__.py
@@ -8,7 +8,7 @@ Supported platforms: Windows, Linux and macOS (32-bit and 64-bit).
 """
 
 __author__ = "Jean Loui Bernard Silva de Jesus"
-__version__ = "2.2.1"
+__version__ = "3.0.0"
 
 import logging
 import sys


### PR DESCRIPTION
Bumps `PyMemoryEditor/__init__.py` to `3.0.0`. Hatch reads the version from
there (`[tool.hatch.version]`), so it is the only place it lives — confirmed by
building an sdist, which came out as `pymemoryeditor-3.0.0.tar.gz`.

## Why major and not minor

One change forces it. `read_process_memory(addr, int, N)` with N in 3, 5, 6 or
7 and the value's top bit set returns a different number now — on every
platform, with no exception raised.

```
bytes in memory: FF FF FF   (a 24-bit unsigned field at its maximum)

2.2.1  ->  16777215
3.0.0  ->  -1
```

Cheat Engine offers a "3 Bytes" type precisely because games cap money and
score in 24-bit fields, and this library exists to reproduce that workflow — so
a reader following a tutorial lands exactly there. An existing script, with no
line changed:

```python
money = process.read_process_memory(addr, int, 3)
if money < 1000:
    process.write_process_memory(addr, int, 3, 16777215)   # "top up"
```

| | value read | `money < 1000` | result |
|---|---|---|---|
| 2.2.1 | 16777215 | `False` | does nothing — correct |
| 3.0.0 | −1 | `True` | **tops up** a field already at maximum |

The guard inverted, and in a memory editor the branch that flips is the one
that **writes**. The round trip also stops closing: the write path's range
check accepts the union of the signed and unsigned ranges, so `16777215` is
still a valid 3-byte write and reads back as `-1`.

**Half the value space** of each affected width changes sign (8388608–16777215
at width 3, and the equivalent band at 5, 6 and 7). Widths 1, 2, 4 and 8 are
untouched, and so is the `int` default of 4.

## Why the other five behaviour changes would not have needed one

Measured across 220 read combinations, only **4** change a value silently — the
ones above. Of the rest, 88 turn a value into a `ValueError`, and no working
code depends on what they returned before:

- a width wider than the type's largest C representation overflowed the
  *caller's* buffer — `get_c_type_of(bool, 8)` sized 1 byte for an 8-byte read,
  and `int` at 16 overflowed 8;
- `float` at any width but 4 or 8 returned a plausible-looking number decoded
  from bytes nobody read (`5.5e-318`);
- Linux read and wrote `sizeof(buffer)` instead of the width asked for, so the
  same call answered differently per platform.

`str` and `bytes` did not change at all — none of their 44 combinations.

## Also shipping

The MCP server (14 tools, opt-in through the `mcp` extra — the core library
stays dependency-free), `iter_processes()` as a dependency-free counterpart to
`psutil.process_iter()`, and `decode_scan_target` / `make_predicate` promoted
from private.

## Ordering

**Merge #96 first.** It is still open, and it adds a session cap whose refusal
is new behaviour an embedder could hit. This branch is a one-line change and
rebases trivially, so it should be the last thing in before the release is cut.
