### PR TITLE
chore: bump version to 3.0.1

### DIFF
--- a/PyMemoryEditor/__init__.py
+++ b/PyMemoryEditor/__init__.py
@@ -8,7 +8,7 @@ Supported platforms: Windows, Linux and macOS (32-bit and 64-bit).
 """
 
 __author__ = "Jean Loui Bernard Silva de Jesus"
-__version__ = "3.0.0"
+__version__ = "3.0.1"
 
 import logging
 import sys

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ copyright = f"{datetime.now().year}, {author}"
 try:
     from PyMemoryEditor import __version__ as release
 except Exception:  # pragma: no cover - docs can build without the package installed
-    release = "2.0.0"
+    release = "3.0.1"
 
 version = ".".join(release.split(".")[:2])
 


### PR DESCRIPTION
## Why

Everything that landed since `v3.0.0` is documentation — #100 regrouped the Sphinx sidebar with toctree captions. No library code changed, so this is a patch.

The bump exists for Read the Docs. RTD serves `/en/stable/` from the highest semver tag, which is still `v3.0.0` — the commit *before* the docs change — so `stable` keeps showing the old navigation even though `/en/latest/` already rebuilt from `main` on merge. Tagging `v3.0.1` is what moves `stable` onto the current docs.

## What changed

- `PyMemoryEditor/__init__.py` — `__version__` to `3.0.1`. This is the only real version declaration; `pyproject.toml` reads it dynamically through `[tool.hatch.version]`.
- `docs/conf.py` — the fallback `release` had been pinned at `2.0.0`. It is only read when the package cannot be imported at build time, so it has never affected a Read the Docs build (RTD installs the package), but it should not drift either.

## Notes

Nothing publishes on merge: `publish.yml` triggers on `release: published`, not on a tag push. The tag and the GitHub release are separate follow-up steps.
